### PR TITLE
Remove encoding cookies from 2 Casks

### DIFF
--- a/Casks/font-lisutzimu.rb
+++ b/Casks/font-lisutzimu.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'font-lisutzimu' do
   version '1.0'
   sha256 '15948eaee1c56b88e04fd17d8520cfe2cd4112a3b4dc2961e2adbc5a4e616ebd'

--- a/Casks/font-seoulhangangcondensed.rb
+++ b/Casks/font-seoulhangangcondensed.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 cask :v1 => 'font-seoulhangangcondensed' do
   url 'http://www.seoul.go.kr/v2012/seoul/symbol/download.php?div=Zm9udDEw'
   homepage 'http://www.seoul.go.kr/v2012/seoul/symbol/font.html'


### PR DESCRIPTION
These UTF-8 encoding cookies were intended to help Ruby 1.9, and should not have had an effect for users running Ruby 2.0.  We no longer need them.

Since caskroom/homebrew-cask#8089 (requiring Ruby 2.0) was only just merged, we should HOLD until 15 Jan.

Sorry if this long-term PR is considered clutter.
