### PR TITLE
Update Powerline fonts repo URLs

### DIFF
--- a/Casks/font-anonymous-pro-for-powerline.rb
+++ b/Casks/font-anonymous-pro-for-powerline.rb
@@ -2,10 +2,10 @@ cask :v1 => 'font-anonymous-pro-for-powerline' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/Lokaltog/powerline-fonts/trunk/AnonymousPro',
+  url 'https://github.com/powerline/fonts/trunk/AnonymousPro',
       :using => :svn,
       :trust_cert => true
-  homepage 'https://github.com/Lokaltog/powerline-fonts/tree/master/AnonymousPro'
+  homepage 'https://github.com/powerline/fonts/tree/master/AnonymousPro'
   license :oss
 
   font 'Anonymice Powerline Bold Italic.ttf'

--- a/Casks/font-dejavu-sans-mono-for-powerline.rb
+++ b/Casks/font-dejavu-sans-mono-for-powerline.rb
@@ -2,10 +2,10 @@ cask :v1 => 'font-dejavu-sans-mono-for-powerline' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/Lokaltog/powerline-fonts/trunk/DejaVuSansMono',
+  url 'https://github.com/powerline/fonts/trunk/DejaVuSansMono',
       :using => :svn,
       :trust_cert => true
-  homepage 'https://github.com/Lokaltog/powerline-fonts/tree/master/DejaVuSansMono'
+  homepage 'https://github.com/powerline/fonts/tree/master/DejaVuSansMono'
   license :oss
 
   font 'DejaVu Sans Mono for Powerline.ttf'

--- a/Casks/font-droid-sans-mono-for-powerline.rb
+++ b/Casks/font-droid-sans-mono-for-powerline.rb
@@ -2,10 +2,10 @@ cask :v1 => 'font-droid-sans-mono-for-powerline' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/Lokaltog/powerline-fonts/trunk/DroidSansMono',
+  url 'https://github.com/powerline/fonts/trunk/DroidSansMono',
       :using => :svn,
       :trust_cert => true
-  homepage 'https://github.com/Lokaltog/powerline-fonts/tree/master/DroidSansMono'
+  homepage 'https://github.com/powerline/fonts/tree/master/DroidSansMono'
   license :oss
 
   font 'Droid Sans Mono for Powerline.otf'

--- a/Casks/font-fira-mono-for-powerline.rb
+++ b/Casks/font-fira-mono-for-powerline.rb
@@ -1,0 +1,14 @@
+cask :v1 => 'font-fira-mono-for-powerline' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://github.com/powerline/fonts/trunk/FiraMono',
+      :using => :svn,
+      :trust_cert => true
+  homepage 'https://github.com/powerline/fonts/tree/master/FiraMono'
+  license :oss
+
+  font 'FuraMono-Bold Powerline.otf'
+  font 'FuraMono-Medium Powerline.otf'
+  font 'FuraMono-Regular Powerline.otf'
+end

--- a/Casks/font-inconsolata-dz-for-powerline.rb
+++ b/Casks/font-inconsolata-dz-for-powerline.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-inconsolata-dz-for-powerline' do
   version :latest
   sha256 :no_check
 
-  url 'https://raw.github.com/Lokaltog/powerline-fonts/master/InconsolataDz/Inconsolata-dz%20for%20Powerline.otf'
-  homepage 'https://github.com/Lokaltog/powerline-fonts/tree/master/InconsolataDz'
+  url 'https://raw.github.com/powerline/fonts/master/InconsolataDz/Inconsolata-dz%20for%20Powerline.otf'
+  homepage 'https://github.com/powerline/fonts/tree/master/InconsolataDz'
   license :ofl
 
   font 'Inconsolata-dz for Powerline.otf'

--- a/Casks/font-inconsolata-for-powerline.rb
+++ b/Casks/font-inconsolata-for-powerline.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-inconsolata-for-powerline' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/Lokaltog/powerline-fonts/raw/master/Inconsolata/Inconsolata%20for%20Powerline.otf'
-  homepage 'https://github.com/Lokaltog/powerline-fonts/tree/master/Inconsolata'
+  url 'https://github.com/powerline/fonts/raw/master/Inconsolata/Inconsolata%20for%20Powerline.otf'
+  homepage 'https://github.com/powerline/fonts/tree/master/Inconsolata'
   license :ofl
 
   font 'Inconsolata for Powerline.otf'

--- a/Casks/font-inconsolata-g-for-powerline.rb
+++ b/Casks/font-inconsolata-g-for-powerline.rb
@@ -2,10 +2,10 @@ cask :v1 => 'font-inconsolata-g-for-powerline' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/Lokaltog/powerline-fonts/trunk/Inconsolata-g',
+  url 'https://github.com/powerline/fonts/trunk/Inconsolata-g',
       :using => :svn,
       :trust_cert => true
-  homepage 'https://github.com/Lokaltog/powerline-fonts/tree/master/Inconsolata-g'
+  homepage 'https://github.com/powerline/fonts/tree/master/Inconsolata-g'
   license :ofl
 
   font 'Inconsolata-g for Powerline.otf'

--- a/Casks/font-liberation-mono-for-powerline.rb
+++ b/Casks/font-liberation-mono-for-powerline.rb
@@ -2,10 +2,10 @@ cask :v1 => 'font-liberation-mono-for-powerline' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/Lokaltog/powerline-fonts/trunk/LiberationMono',
+  url 'https://github.com/powerline/fonts/trunk/LiberationMono',
       :using => :svn,
       :trust_cert => true
-  homepage 'https://github.com/Lokaltog/powerline-fonts/tree/master/LiberationMono'
+  homepage 'https://github.com/powerline/fonts/tree/master/LiberationMono'
   license :oss
 
   font 'Literation Mono Powerline Bold Italic.ttf'

--- a/Casks/font-meslo-lg-for-powerline.rb
+++ b/Casks/font-meslo-lg-for-powerline.rb
@@ -2,10 +2,10 @@ cask :v1 => 'font-meslo-lg-for-powerline' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/Lokaltog/powerline-fonts/trunk/Meslo',
+  url 'https://github.com/powerline/fonts/trunk/Meslo',
       :using => :svn,
       :trust_cert => true
-  homepage 'https://github.com/Lokaltog/powerline-fonts/tree/master/Meslo'
+  homepage 'https://github.com/powerline/fonts/tree/master/Meslo'
   license :oss
 
   font 'Meslo LG L DZ Regular for Powerline.otf'

--- a/Casks/font-sauce-code-powerline.rb
+++ b/Casks/font-sauce-code-powerline.rb
@@ -3,11 +3,11 @@ cask :v1 => 'font-sauce-code-powerline' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/Lokaltog/powerline-fonts/trunk/SourceCodePro',
+  url 'https://github.com/powerline/fonts/trunk/SourceCodePro',
       :using      => :svn,
       :revision   => '50',
       :trust_cert => true
-  homepage 'https://github.com/Lokaltog/powerline-fonts/tree/master/SourceCodePro'
+  homepage 'https://github.com/powerline/fonts/tree/master/SourceCodePro'
   license :oss
 
   font 'Sauce Code Powerline Black.otf'

--- a/Casks/font-source-code-pro-for-powerline.rb
+++ b/Casks/font-source-code-pro-for-powerline.rb
@@ -1,0 +1,18 @@
+cask :v1 => 'font-source-code-pro-for-powerline' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://github.com/powerline/fonts/trunk/SourceCodePro',
+      :using => :svn,
+      :trust_cert => true
+  homepage 'https://github.com/powerline/fonts/tree/master/SourceCodePro'
+  license :oss
+
+  font 'Sauce Code Powerline Black.otf'
+  font 'Sauce Code Powerline Bold.otf'
+  font 'Sauce Code Powerline ExtraLight.otf'
+  font 'Sauce Code Powerline Light.otf'
+  font 'Sauce Code Powerline Medium.otf'
+  font 'Sauce Code Powerline Regular.otf'
+  font 'Sauce Code Powerline Semibold.otf'
+end

--- a/Casks/font-ubuntu-mono-powerline.rb
+++ b/Casks/font-ubuntu-mono-powerline.rb
@@ -3,11 +3,11 @@ cask :v1 => 'font-ubuntu-mono-powerline' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/Lokaltog/powerline-fonts/trunk/UbuntuMono',
+  url 'https://github.com/powerline/fonts/trunk/UbuntuMono',
       :using      => :svn,
       :revision   => '53',
       :trust_cert => true
-  homepage 'https://github.com/Lokaltog/powerline-fonts/tree/master/UbuntuMono'
+  homepage 'https://github.com/powerline/fonts/tree/master/UbuntuMono'
   license :ubuntu_font
 
   font 'Ubuntu Mono derivative Powerline.ttf'


### PR DESCRIPTION
- Updated powerline fonts repo URLs _[current repo](https://github.com/powerline/fonts)_
- Added Fira mono & Source code pro for powerline.