### PR TITLE
Ricty Diminished

### DIFF
--- a/Casks/font-ricty-diminished.rb
+++ b/Casks/font-ricty-diminished.rb
@@ -1,0 +1,17 @@
+cask :v1 => 'font-ricty-diminished' do
+  version '3.2.4'
+  sha256 'd8ae378f6333080da83ba1ab3a7cb5f3ed0982a2e633de651b9510cb7dcd3bfc'
+
+  url 'https://github.com/yascentur/RictyDiminished/archive/3.2.4.zip'
+  homepage 'https://github.com/yascentur/RictyDiminished'
+  license :oss
+
+  font 'RictyDiminished-3.2.4/RictyDiminished-Bold.ttf'
+  font 'RictyDiminished-3.2.4/RictyDiminished-BoldOblique.ttf'
+  font 'RictyDiminished-3.2.4/RictyDiminished-Oblique.ttf'
+  font 'RictyDiminished-3.2.4/RictyDiminished-Regular.ttf'
+  font 'RictyDiminished-3.2.4/RictyDiminishedDiscord-Bold.ttf'
+  font 'RictyDiminished-3.2.4/RictyDiminishedDiscord-BoldOblique.ttf'
+  font 'RictyDiminished-3.2.4/RictyDiminishedDiscord-Oblique.ttf'
+  font 'RictyDiminished-3.2.4/RictyDiminishedDiscord-Regular.ttf'
+end


### PR DESCRIPTION
Ricty Dinimished is a collection of fonts for programmers who use Kanji (Chinese characters).
For details see https://github.com/yascentur/RictyDiminished