### PR TITLE
Updating Font Awesome Cask

### DIFF
--- a/Casks/font-fontawesome.rb
+++ b/Casks/font-fontawesome.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'font-fontawesome' do
   version '4.2.0'
-  sha256 'b0f2792a2a096ccebe72cfcf1880671658a1f18d5356c5f991b2b54d8f6bf704'
+  sha256 'b68b47c5e6da744fc78393eeae0cb16e3844a76b505855c99ff50e99c680b5c0'
 
-  url "http://fontawesome.io/assets/font-awesome-#{version}.zip"
+  url "https://github.com/FortAwesome/Font-Awesome/archive/v4.2.0.zip"
   homepage 'http://fortawesome.github.io/Font-Awesome/'
   license :oss
 


### PR DESCRIPTION
The current font-fontawesome cask is broken, because the zip file is not longer available, I updated the sha and the download link for the version 4.2.0