### PR TITLE
Add Linux Libertine and Linux Biolinum font casks

### DIFF
--- a/Casks/font-linux-biolinum.rb
+++ b/Casks/font-linux-biolinum.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'font-linux-biolinum' do
+  version '5.3.0'
+  sha256 '24a593a949808d976850131a953c0c0d7a72299531dfbb348191964cc038d75d'
+
+  url 'http://downloads.sourceforge.net/project/linuxlibertine/linuxlibertine/5.3.0/LinLibertineTTF_5.3.0_2012_07_02.tgz'
+  homepage 'http://linuxlibertine.org'
+  license :ofl
+
+  font 'LinBiolinum_Kah.ttf'
+  font 'LinBiolinum_RBah.ttf'
+  font 'LinBiolinum_RIah.ttf'
+  font 'LinBiolinum_Rah.ttf'
+end

--- a/Casks/font-linux-libertine.rb
+++ b/Casks/font-linux-libertine.rb
@@ -1,0 +1,18 @@
+cask :v1 => 'font-linux-libertine' do
+  version '5.3.0'
+  sha256 '24a593a949808d976850131a953c0c0d7a72299531dfbb348191964cc038d75d'
+
+  url 'http://downloads.sourceforge.net/project/linuxlibertine/linuxlibertine/5.3.0/LinLibertineTTF_5.3.0_2012_07_02.tgz'
+  homepage 'http://linuxlibertine.org'
+  license :ofl
+
+  font 'LinLibertine_DRah.ttf'
+  font 'LinLibertine_I.ttf'
+  font 'LinLibertine_Mah.ttf'
+  font 'LinLibertine_RBIah.ttf'
+  font 'LinLibertine_RBah.ttf'
+  font 'LinLibertine_RIah.ttf'
+  font 'LinLibertine_RZIah.ttf'
+  font 'LinLibertine_RZah.ttf'
+  font 'LinLibertine_Rah.ttf'
+end


### PR DESCRIPTION
Casks for two fonts from the Libertine Open Fonts Project, both available under the OFL.

* Home page: http://www.linuxlibertine.org/
* Licence: http://www.linuxlibertine.org/index.php?id=91&L=1