### PR TITLE
Fix CJK font file name

### DIFF
--- a/Casks/font-noto-sans-japanese.rb
+++ b/Casks/font-noto-sans-japanese.rb
@@ -6,11 +6,11 @@ cask :v1 => 'font-noto-sans-japanese' do
   homepage 'http://www.google.com/get/noto/#/family/noto-sans-jpan'
   license :apache
 
-  font 'NotoSansJP-Black.otf'
-  font 'NotoSansJP-Bold.otf'
-  font 'NotoSansJP-DemiLight.otf'
-  font 'NotoSansJP-Light.otf'
-  font 'NotoSansJP-Medium.otf'
-  font 'NotoSansJP-Regular.otf'
-  font 'NotoSansJP-Thin.otf'
+  font 'NotoSansCJKjp-Black.otf'
+  font 'NotoSansCJKjp-Bold.otf'
+  font 'NotoSansCJKjp-DemiLight.otf'
+  font 'NotoSansCJKjp-Light.otf'
+  font 'NotoSansCJKjp-Medium.otf'
+  font 'NotoSansCJKjp-Regular.otf'
+  font 'NotoSansCJKjp-Thin.otf'
 end

--- a/Casks/font-noto-sans-korean.rb
+++ b/Casks/font-noto-sans-korean.rb
@@ -6,11 +6,11 @@ cask :v1 => 'font-noto-sans-korean' do
   homepage 'http://www.google.com/get/noto/#/family/noto-sans-kore'
   license :apache
 
-  font 'NotoSansKR-Black.otf'
-  font 'NotoSansKR-Bold.otf'
-  font 'NotoSansKR-DemiLight.otf'
-  font 'NotoSansKR-Light.otf'
-  font 'NotoSansKR-Medium.otf'
-  font 'NotoSansKR-Regular.otf'
-  font 'NotoSansKR-Thin.otf'
+  font 'NotoSansCJKkr-Black.otf'
+  font 'NotoSansCJKkr-Bold.otf'
+  font 'NotoSansCJKkr-DemiLight.otf'
+  font 'NotoSansCJKkr-Light.otf'
+  font 'NotoSansCJKkr-Medium.otf'
+  font 'NotoSansCJKkr-Regular.otf'
+  font 'NotoSansCJKkr-Thin.otf'
 end

--- a/Casks/font-noto-sans-s-chinese.rb
+++ b/Casks/font-noto-sans-s-chinese.rb
@@ -6,11 +6,11 @@ cask :v1 => 'font-noto-sans-s-chinese' do
   homepage 'http://www.google.com/get/noto/#/family/noto-sans-hans'
   license :apache
 
-  font 'NotoSansHans-Black.otf'
-  font 'NotoSansHans-Bold.otf'
-  font 'NotoSansHans-DemiLight.otf'
-  font 'NotoSansHans-Light.otf'
-  font 'NotoSansHans-Medium.otf'
-  font 'NotoSansHans-Regular.otf'
-  font 'NotoSansHans-Thin.otf'
+  font 'NotoSansCJKsc-Black.otf'
+  font 'NotoSansCJKsc-Bold.otf'
+  font 'NotoSansCJKsc-DemiLight.otf'
+  font 'NotoSansCJKsc-Light.otf'
+  font 'NotoSansCJKsc-Medium.otf'
+  font 'NotoSansCJKsc-Regular.otf'
+  font 'NotoSansCJKsc-Thin.otf'
 end

--- a/Casks/font-noto-sans-t-chinese.rb
+++ b/Casks/font-noto-sans-t-chinese.rb
@@ -6,11 +6,11 @@ cask :v1 => 'font-noto-sans-t-chinese' do
   homepage 'http://www.google.com/get/noto/#/family/noto-sans-hant'
   license :apache
 
-  font 'NotoSansHant-Black.otf'
-  font 'NotoSansHant-Bold.otf'
-  font 'NotoSansHant-DemiLight.otf'
-  font 'NotoSansHant-Light.otf'
-  font 'NotoSansHant-Medium.otf'
-  font 'NotoSansHant-Regular.otf'
-  font 'NotoSansHant-Thin.otf'
+  font 'NotoSansCJKtc-Black.otf'
+  font 'NotoSansCJKtc-Bold.otf'
+  font 'NotoSansCJKtc-DemiLight.otf'
+  font 'NotoSansCJKtc-Light.otf'
+  font 'NotoSansCJKtc-Medium.otf'
+  font 'NotoSansCJKtc-Regular.otf'
+  font 'NotoSansCJKtc-Thin.otf'
 end


### PR DESCRIPTION
CJK fonts
(Japanese, Korean, Simplified Chinese, Traditional Chinese)
These fonts file name are different from other Noto font file name.
This commit is fix that.