### PR TITLE
Update url for Google fonts which moved from apache to ofl.

### DIFF
--- a/Casks/font-exo2.rb
+++ b/Casks/font-exo2.rb
@@ -3,7 +3,7 @@ cask :v1 => 'font-exo2' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/google/fonts/trunk/apache/exo2',
+  url 'https://github.com/google/fonts/trunk/ofl/exo2',
       :using      => :svn,
       :revision   => '50',
       :trust_cert => true

--- a/Casks/font-exo2.rb
+++ b/Casks/font-exo2.rb
@@ -8,7 +8,7 @@ cask :v1 => 'font-exo2' do
       :revision   => '50',
       :trust_cert => true
   homepage 'http://www.google.com/fonts/specimen/Exo%202'
-  license :oss
+  license :ofl
 
   font 'Exo2-Black.ttf'
   font 'Exo2-BlackItalic.ttf'

--- a/Casks/font-nanumgothic.rb
+++ b/Casks/font-nanumgothic.rb
@@ -3,7 +3,7 @@ cask :v1 => 'font-nanumgothic' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/google/fonts/trunk/apache/nanumgothic',
+  url 'https://github.com/google/fonts/trunk/ofl/nanumgothic',
       :using      => :svn,
       :revision   => '50',
       :trust_cert => true

--- a/Casks/font-nanumgothic.rb
+++ b/Casks/font-nanumgothic.rb
@@ -8,7 +8,7 @@ cask :v1 => 'font-nanumgothic' do
       :revision   => '50',
       :trust_cert => true
   homepage 'https://www.google.com/fonts/earlyaccess'
-  license :oss
+  license :ofl
 
   font 'NanumGothic-Bold.ttf'
   font 'NanumGothic-ExtraBold.ttf'

--- a/Casks/font-nanumgothiccoding.rb
+++ b/Casks/font-nanumgothiccoding.rb
@@ -8,7 +8,7 @@ cask :v1 => 'font-nanumgothiccoding' do
       :revision   => '50',
       :trust_cert => true
   homepage 'https://www.google.com/fonts/earlyaccess'
-  license :oss
+  license :ofl
 
   font 'NanumGothicCoding-Bold.ttf'
   font 'NanumGothicCoding-Regular.ttf'

--- a/Casks/font-nanumgothiccoding.rb
+++ b/Casks/font-nanumgothiccoding.rb
@@ -3,7 +3,7 @@ cask :v1 => 'font-nanumgothiccoding' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/google/fonts/trunk/apache/nanumgothiccoding',
+  url 'https://github.com/google/fonts/trunk/ofl/nanumgothiccoding',
       :using      => :svn,
       :revision   => '50',
       :trust_cert => true

--- a/Casks/font-nanummyeongjo.rb
+++ b/Casks/font-nanummyeongjo.rb
@@ -8,7 +8,7 @@ cask :v1 => 'font-nanummyeongjo' do
       :revision   => '50',
       :trust_cert => true
   homepage 'https://www.google.com/fonts/earlyaccess'
-  license :oss
+  license :ofl
 
   font 'NanumMyeongjo-Bold.ttf'
   font 'NanumMyeongjo-ExtraBold.ttf'

--- a/Casks/font-nanummyeongjo.rb
+++ b/Casks/font-nanummyeongjo.rb
@@ -3,7 +3,7 @@ cask :v1 => 'font-nanummyeongjo' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/google/fonts/trunk/apache/nanummyeongjo',
+  url 'https://github.com/google/fonts/trunk/ofl/nanummyeongjo',
       :using      => :svn,
       :revision   => '50',
       :trust_cert => true

--- a/Casks/font-padauk.rb
+++ b/Casks/font-padauk.rb
@@ -3,7 +3,7 @@ cask :v1 => 'font-padauk' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/google/fonts/trunk/apache/padauk',
+  url 'https://github.com/google/fonts/trunk/ofl/padauk',
       :using      => :svn,
       :revision   => '50',
       :trust_cert => true

--- a/Casks/font-padauk.rb
+++ b/Casks/font-padauk.rb
@@ -8,7 +8,7 @@ cask :v1 => 'font-padauk' do
       :revision   => '50',
       :trust_cert => true
   homepage 'https://www.google.com/fonts/earlyaccess'
-  license :oss
+  license :ofl
 
   font 'Padauk-Bold.ttf'
   font 'Padauk-Regular.ttf'


### PR DESCRIPTION
I had identified `exo2` had an issue and did a search through out the whole of homebrew-fonts with a matching pattern for `trunk/apache` in the url. I checked to see if each one had moved in the google-fonts project and if they had I updated the url.