### PR TITLE
Add cask for Fira Code v0.3

### DIFF
--- a/font-fira-code.rb
+++ b/font-fira-code.rb
@@ -1,0 +1,10 @@
+cask :v1 => 'font-fira-code' do
+  version '0.3'
+  sha256 'a90721b6b1de4640ace744657432a990aae4c8e403b78141a50d0a7abd305db7'
+
+  url 'https://github.com/tonsky/FiraCode/releases/download/0.3/FiraCode-Regular.otf'
+  homepage 'https://github.com/tonsky/FiraCode'
+  license :ofl
+
+  font 'FiraCode-Regular.otf'
+end


### PR DESCRIPTION
The Firefox Fira monospaced font with programming ligatures, based on Hasklig.