### PR TITLE
Update sha256 for font-source-* fonts.

### DIFF
--- a/Casks/font-source-code-pro.rb
+++ b/Casks/font-source-code-pro.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'font-source-code-pro' do
   version '1.017R'
-  sha256 '0c3065b2f411a117e85a2a0e8d66f9276821cd1e2a6853063f7e9a213bc9ec45'
+  sha256 '6753300ddc8f7c1e40bb64e3b0842ba0abcafa3cb92889d7c7a1ba2c8b0dfa82'
 
   url "https://github.com/adobe-fonts/source-code-pro/archive/#{version}.zip"
   homepage 'http://adobe-fonts.github.io/source-code-pro/'

--- a/Casks/font-source-sans-pro.rb
+++ b/Casks/font-source-sans-pro.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'font-source-sans-pro' do
   version '2.010'
-  sha256 '845285e4bf9f3f0aa2e77dec53b2be66c0acdd3096452638750a9ae3423039bc'
+  sha256 '98c3bb8fb61037eafe70873f0bf3e95685efe506d7974c23ecce06156f808843'
 
   url "https://github.com/adobe-fonts/source-sans-pro/archive/#{version}R-ro/1.065R-it.zip"
   homepage 'http://store1.adobe.com/cfusion/store/html/index.cfm?store=OLS-US&event=displayFontPackage&code=1959'

--- a/Casks/font-source-serif-pro.rb
+++ b/Casks/font-source-serif-pro.rb
@@ -1,6 +1,6 @@
 cask :v1 => 'font-source-serif-pro' do
   version '1.017R'
-  sha256 'bec4adae1e138ea947eb97a5ddda6413ef683313490b33e53aaba81f37c20725'
+  sha256 '778d74156b58bc1a7c7313cad2e1c35f33fb84e8674074339f5723bcc5c301d9'
 
   url "https://github.com/adobe-fonts/source-serif-pro/archive/#{version}.zip"
   homepage 'http://adobe.github.io/source-serif-pro/'


### PR DESCRIPTION
I've noticed that the sha256 values for the `font-source-*` Casks has changed.

I'm not sure why, and I can't see a reason on the github repository.

This PR captures the new sha256 values for the Casks.