### PR TITLE
Fix font-office-code-pro file paths

### DIFF
--- a/Casks/font-office-code-pro.rb
+++ b/Casks/font-office-code-pro.rb
@@ -6,12 +6,12 @@ cask :v1 => 'font-office-code-pro' do
   homepage 'https://github.com/nathco/Office-Code-Pro'
   license :ofl
 
-  font 'Office-Code-Pro-master/Fonts/OTF/OfficeCodePro-Bold.otf'
-  font 'Office-Code-Pro-master/Fonts/OTF/OfficeCodePro-BoldD.otf'
-  font 'Office-Code-Pro-master/Fonts/OTF/OfficeCodePro-Light.otf'
-  font 'Office-Code-Pro-master/Fonts/OTF/OfficeCodePro-LightD.otf'
-  font 'Office-Code-Pro-master/Fonts/OTF/OfficeCodePro-Medium.otf'
-  font 'Office-Code-Pro-master/Fonts/OTF/OfficeCodePro-MediumD.otf'
-  font 'Office-Code-Pro-master/Fonts/OTF/OfficeCodePro-Regular.otf'
-  font 'Office-Code-Pro-master/Fonts/OTF/OfficeCodePro-RegularD.otf'
+  font 'Office-Code-Pro-master/Fonts/Office Code Pro/OTF/OfficeCodePro-Bold.otf'
+  font 'Office-Code-Pro-master/Fonts/Office Code Pro/OTF/OfficeCodePro-BoldD.otf'
+  font 'Office-Code-Pro-master/Fonts/Office Code Pro/OTF/OfficeCodePro-Light.otf'
+  font 'Office-Code-Pro-master/Fonts/Office Code Pro/OTF/OfficeCodePro-LightD.otf'
+  font 'Office-Code-Pro-master/Fonts/Office Code Pro/OTF/OfficeCodePro-Medium.otf'
+  font 'Office-Code-Pro-master/Fonts/Office Code Pro/OTF/OfficeCodePro-MediumD.otf'
+  font 'Office-Code-Pro-master/Fonts/Office Code Pro/OTF/OfficeCodePro-Regular.otf'
+  font 'Office-Code-Pro-master/Fonts/Office Code Pro/OTF/OfficeCodePro-RegularD.otf'
 end


### PR DESCRIPTION
The fonts have been moved to subdirectory, to differentiate from the dotted zero version.

Currently when I try to install I get this:

```bash
$ brew cask install font-office-code-pro
==> Downloading https://github.com/nathco/Office-Code-Pro/archive/master.zip
######################################################################## 100.0%
Error: It seems the hardlink source is not there: '/opt/homebrew-cask/Caskroom/font-office-code-pro/latest/Office-Code-Pro-master/Fonts/OTF/OfficeCodePro-Bold.otf'
```