### PR TITLE
font-material-icons update version number.

### DIFF
--- a/Casks/font-material-icons.rb
+++ b/Casks/font-material-icons.rb
@@ -1,5 +1,5 @@
 cask :v1 => 'font-material-icons' do
-  version '2.0'
+  version '2.0.0'
   sha256 '2e75ad776d1d9251215c14f887d55c1f7649561eed65928a42aeacdccc62322d'
 
   url "https://github.com/google/material-design-icons/releases/download/#{version}/material-design-icons-#{version}.zip"


### PR DESCRIPTION
https://github.com/google/material-design-icons/releases/tag/2.0