### PR TITLE
add Libertine fonts (fork of Linux Libertine/Biolinum)

### DIFF
--- a/Casks/font-libertine.rb
+++ b/Casks/font-libertine.rb
@@ -1,0 +1,23 @@
+cask :v1 => 'font-libertine' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://github.com/khaledhosny/libertine/archive/master.tar.gz'
+  homepage 'https://github.com/khaledhosny/libertine'
+  license :ofl
+
+  font 'libertine-master/libertinekeyboard-regular.otf'
+  font 'libertine-master/libertinemath-regular.otf'
+  font 'libertine-master/libertinemono-regular.otf'
+  font 'libertine-master/libertinesans-bold.otf'
+  font 'libertine-master/libertinesans-italic.otf'
+  font 'libertine-master/libertinesans-regular.otf'
+  font 'libertine-master/libertineserif-bold.otf'
+  font 'libertine-master/libertineserif-bolditalic.otf'
+  font 'libertine-master/libertineserif-italic.otf'
+  font 'libertine-master/libertineserif-regular.otf'
+  font 'libertine-master/libertineserif-semibold.otf'
+  font 'libertine-master/libertineserif-semibolditalic.otf'
+  font 'libertine-master/libertineserifdisplay-regular.otf'
+  font 'libertine-master/libertineserifinitials-regular.otf'
+end


### PR DESCRIPTION
The 'Linux Libertine' family is a great font family but the original
developer has been inactive for several years and the bug list is piling
up. A fork project know as just "Libertine' has many of the
long-standing issues fixed and has expanded the family with a math font.
The font faces have been renamed to not conflict with the original
project.