### PR TITLE
Fix font-questrial download URL

### DIFF
--- a/Casks/font-questrial.rb
+++ b/Casks/font-questrial.rb
@@ -1,8 +1,8 @@
 cask :v1 => 'font-questrial' do
-  version '1.002'
-  sha256 '7939901e928aaa8aa17a5eb509133410ea0b40e92ac49fd035bfc191d549ed9e'
+  version :latest
+  sha256 :no_check
 
-  url 'https://googlefontdirectory.googlecode.com/hg-history/67342bc472599b4c32201ee4a002fe59a6447a42/ofl/questrial/Questrial-Regular.ttf'
+  url 'https://github.com/google/fonts/raw/master/ofl/questrial/Questrial-Regular.ttf'
   homepage 'http://www.google.com/fonts/specimen/Questrial'
   license :ofl
 


### PR DESCRIPTION
Use GitHub's Google Fonts repository to retrieve the font.