### PR TITLE
Update URL and homepage for Google Noto font family

### DIFF
--- a/Casks/font-noto-kufi-arabic.rb
+++ b/Casks/font-noto-kufi-arabic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-kufi-arabic' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoKufiArabic-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoKufiArabic-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoKufiArabic-Bold.ttf'

--- a/Casks/font-noto-naskh-arabic.rb
+++ b/Casks/font-noto-naskh-arabic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-naskh-arabic' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoNaskhArabic-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoNaskhArabic-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoNaskhArabic-Bold.ttf'

--- a/Casks/font-noto-sans-armenian.rb
+++ b/Casks/font-noto-sans-armenian.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-armenian' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansArmenian-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansArmenian-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansArmenian-Regular.ttf'

--- a/Casks/font-noto-sans-avestan.rb
+++ b/Casks/font-noto-sans-avestan.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-avestan' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansAvestan-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansAvestan-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansAvestan-Regular.ttf'

--- a/Casks/font-noto-sans-balinese.rb
+++ b/Casks/font-noto-sans-balinese.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-balinese' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansBalinese-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansBalinese-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansBalinese-Regular.ttf'

--- a/Casks/font-noto-sans-bamum.rb
+++ b/Casks/font-noto-sans-bamum.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-bamum' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansBamum-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansBamum-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansBamum-Regular.ttf'

--- a/Casks/font-noto-sans-batak.rb
+++ b/Casks/font-noto-sans-batak.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-batak' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansBatak-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansBatak-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansBatak-Regular.ttf'

--- a/Casks/font-noto-sans-bengali.rb
+++ b/Casks/font-noto-sans-bengali.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-bengali' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansBengali-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansBengali-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansBengali-Bold.ttf'

--- a/Casks/font-noto-sans-brahmi.rb
+++ b/Casks/font-noto-sans-brahmi.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-brahmi' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansBrahmi-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansBrahmi-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansBrahmi-Regular.ttf'

--- a/Casks/font-noto-sans-buginese.rb
+++ b/Casks/font-noto-sans-buginese.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-buginese' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansBuginese-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansBuginese-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansBuginese-Regular.ttf'

--- a/Casks/font-noto-sans-buhid.rb
+++ b/Casks/font-noto-sans-buhid.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-buhid' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansBuhid-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansBuhid-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansBuhid-Regular.ttf'

--- a/Casks/font-noto-sans-canadian-aboriginal.rb
+++ b/Casks/font-noto-sans-canadian-aboriginal.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-canadian-aboriginal' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansCanadianAboriginal-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansCanadianAboriginal-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansCanadianAboriginal-Regular.ttf'

--- a/Casks/font-noto-sans-carian.rb
+++ b/Casks/font-noto-sans-carian.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-carian' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansCarian-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansCarian-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansCarian-Regular.ttf'

--- a/Casks/font-noto-sans-cham.rb
+++ b/Casks/font-noto-sans-cham.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-cham' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansCham-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansCham-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansCham-Bold.ttf'

--- a/Casks/font-noto-sans-cherokee.rb
+++ b/Casks/font-noto-sans-cherokee.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-cherokee' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansCherokee-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansCherokee-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansCherokee-Regular.ttf'

--- a/Casks/font-noto-sans-coptic.rb
+++ b/Casks/font-noto-sans-coptic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-coptic' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansCoptic-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansCoptic-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansCoptic-Regular.ttf'

--- a/Casks/font-noto-sans-cypriot.rb
+++ b/Casks/font-noto-sans-cypriot.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-cypriot' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansCypriot-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansCypriot-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansCypriot-Regular.ttf'

--- a/Casks/font-noto-sans-deseret.rb
+++ b/Casks/font-noto-sans-deseret.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-deseret' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansDeseret-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansDeseret-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansDeseret-Regular.ttf'

--- a/Casks/font-noto-sans-devanagari.rb
+++ b/Casks/font-noto-sans-devanagari.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-devanagari' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansDevanagari-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansDevanagari-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansDevanagari-Bold.ttf'

--- a/Casks/font-noto-sans-egyptian-hieroglyphs.rb
+++ b/Casks/font-noto-sans-egyptian-hieroglyphs.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-egyptian-hieroglyphs' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansEgyptianHieroglyphs-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansEgyptianHieroglyphs-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansEgyptianHieroglyphs-Regular.ttf'

--- a/Casks/font-noto-sans-ethiopic.rb
+++ b/Casks/font-noto-sans-ethiopic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-ethiopic' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansEthiopic-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansEthiopic-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansEthiopic-Regular.ttf'

--- a/Casks/font-noto-sans-georgian.rb
+++ b/Casks/font-noto-sans-georgian.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-georgian' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansGeorgian-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansGeorgian-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansGeorgian-Bold.ttf'

--- a/Casks/font-noto-sans-glagolitic.rb
+++ b/Casks/font-noto-sans-glagolitic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-glagolitic' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansGlagolitic-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansGlagolitic-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansGlagolitic-Regular.ttf'

--- a/Casks/font-noto-sans-gothic.rb
+++ b/Casks/font-noto-sans-gothic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-gothic' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansGothic-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansGothic-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansGothic-Regular.ttf'

--- a/Casks/font-noto-sans-gujarati.rb
+++ b/Casks/font-noto-sans-gujarati.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-gujarati' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansGujarati-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansGujarati-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansGujarati-Bold.ttf'

--- a/Casks/font-noto-sans-gurmukhi.rb
+++ b/Casks/font-noto-sans-gurmukhi.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-gurmukhi' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansGurmukhi-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansGurmukhi-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansGurmukhi-Bold.ttf'

--- a/Casks/font-noto-sans-hanunoo.rb
+++ b/Casks/font-noto-sans-hanunoo.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-hanunoo' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansHanunoo-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansHanunoo-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansHanunoo-Regular.ttf'

--- a/Casks/font-noto-sans-hebrew.rb
+++ b/Casks/font-noto-sans-hebrew.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-hebrew' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansHebrew-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansHebrew-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansHebrew-Regular.ttf'

--- a/Casks/font-noto-sans-imperial-aramaic.rb
+++ b/Casks/font-noto-sans-imperial-aramaic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-imperial-aramaic' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansImperialAramaic-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansImperialAramaic-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansImperialAramaic-Regular.ttf'

--- a/Casks/font-noto-sans-inscriptional-pahlavi.rb
+++ b/Casks/font-noto-sans-inscriptional-pahlavi.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-inscriptional-pahlavi' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansInscriptionalPahlavi-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansInscriptionalPahlavi-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansPahlavi-Regular.ttf'

--- a/Casks/font-noto-sans-inscriptional-parthian.rb
+++ b/Casks/font-noto-sans-inscriptional-parthian.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-inscriptional-parthian' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansInscriptionalParthian-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansInscriptionalParthian-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansParthian-Regular.ttf'

--- a/Casks/font-noto-sans-japanese.rb
+++ b/Casks/font-noto-sans-japanese.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-japanese' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.google.com/get/noto/pkgs/NotoSansCJKJP-hinted.zip'
-  homepage 'http://www.google.com/get/noto/#/family/noto-sans-jpan'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKJP-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansCJKjp-Black.otf'

--- a/Casks/font-noto-sans-javanese.rb
+++ b/Casks/font-noto-sans-javanese.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-javanese' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansJavanese-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansJavanese-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansJavanese-Regular.ttf'

--- a/Casks/font-noto-sans-kaithi.rb
+++ b/Casks/font-noto-sans-kaithi.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-kaithi' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansKaithi-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansKaithi-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansKaithi-Regular.ttf'

--- a/Casks/font-noto-sans-kannada.rb
+++ b/Casks/font-noto-sans-kannada.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-kannada' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansKannada-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansKannada-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansKannada-Bold.ttf'

--- a/Casks/font-noto-sans-kayah-li.rb
+++ b/Casks/font-noto-sans-kayah-li.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-kayah-li' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansKayahLi-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansKayahLi-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansKayahLi-Regular.ttf'

--- a/Casks/font-noto-sans-kharoshthi.rb
+++ b/Casks/font-noto-sans-kharoshthi.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-kharoshthi' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansKharoshthi-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansKharoshthi-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansKharoshthi-Regular.ttf'

--- a/Casks/font-noto-sans-khmer.rb
+++ b/Casks/font-noto-sans-khmer.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-khmer' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansKhmer-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansKhmer-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansKhmer-Regular.ttf'

--- a/Casks/font-noto-sans-korean.rb
+++ b/Casks/font-noto-sans-korean.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-korean' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.google.com/get/noto/pkgs/NotoSansCJKKR-hinted.zip'
-  homepage 'http://www.google.com/get/noto/#/family/noto-sans-kore'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKKR-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansCJKkr-Black.otf'

--- a/Casks/font-noto-sans-lao.rb
+++ b/Casks/font-noto-sans-lao.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-lao' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansLao-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansLao-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansLao-Bold.ttf'

--- a/Casks/font-noto-sans-lepcha.rb
+++ b/Casks/font-noto-sans-lepcha.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-lepcha' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansLepcha-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansLepcha-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansLepcha-Regular.ttf'

--- a/Casks/font-noto-sans-limbu.rb
+++ b/Casks/font-noto-sans-limbu.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-limbu' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansLimbu-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansLimbu-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansLimbu-Regular.ttf'

--- a/Casks/font-noto-sans-linear-b.rb
+++ b/Casks/font-noto-sans-linear-b.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-linear-b' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansLinearB-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansLinearB-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansLinearB-Regular.ttf'

--- a/Casks/font-noto-sans-lisu.rb
+++ b/Casks/font-noto-sans-lisu.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-lisu' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansLisu-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansLisu-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansLisu-Regular.ttf'

--- a/Casks/font-noto-sans-lycian.rb
+++ b/Casks/font-noto-sans-lycian.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-lycian' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansLycian-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansLycian-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansLycian-Regular.ttf'

--- a/Casks/font-noto-sans-lydian.rb
+++ b/Casks/font-noto-sans-lydian.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-lydian' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansLydian-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansLydian-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansLydian-Regular.ttf'

--- a/Casks/font-noto-sans-malayalam.rb
+++ b/Casks/font-noto-sans-malayalam.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-malayalam' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansMalayalam-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansMalayalam-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansMalayalam-Regular.ttf'

--- a/Casks/font-noto-sans-mandaic.rb
+++ b/Casks/font-noto-sans-mandaic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-mandaic' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansMandaic-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansMandaic-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansMandaic-Regular.ttf'

--- a/Casks/font-noto-sans-meetei-mayek.rb
+++ b/Casks/font-noto-sans-meetei-mayek.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-meetei-mayek' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansMeeteiMayek-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansMeeteiMayek-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansMeeteiMayek-Regular.ttf'

--- a/Casks/font-noto-sans-mongolian.rb
+++ b/Casks/font-noto-sans-mongolian.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-mongolian' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansMongolian-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansMongolian-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansMongolian-Regular.ttf'

--- a/Casks/font-noto-sans-myanmar.rb
+++ b/Casks/font-noto-sans-myanmar.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-myanmar' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansMyanmar-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansMyanmar-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansMyanmar-Bold.ttf'

--- a/Casks/font-noto-sans-n-ko.rb
+++ b/Casks/font-noto-sans-n-ko.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-n-ko' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansNKo-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansNKo-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansNKo-Regular.ttf'

--- a/Casks/font-noto-sans-new-tai-lue.rb
+++ b/Casks/font-noto-sans-new-tai-lue.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-new-tai-lue' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansNewTaiLue-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansNewTaiLue-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansNewTaiLue-Regular.ttf'

--- a/Casks/font-noto-sans-ogham.rb
+++ b/Casks/font-noto-sans-ogham.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-ogham' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansOgham-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOgham-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansOgham-Regular.ttf'

--- a/Casks/font-noto-sans-ol-chiki.rb
+++ b/Casks/font-noto-sans-ol-chiki.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-ol-chiki' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansOlChiki-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOlChiki-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansOlChiki-Regular.ttf'

--- a/Casks/font-noto-sans-old-italic.rb
+++ b/Casks/font-noto-sans-old-italic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-old-italic' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansOldItalic-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOldItalic-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansOldItalic-Regular.ttf'

--- a/Casks/font-noto-sans-old-persian.rb
+++ b/Casks/font-noto-sans-old-persian.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-old-persian' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansOldPersian-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOldPersian-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansOldPersian-Regular.ttf'

--- a/Casks/font-noto-sans-old-south-arabian.rb
+++ b/Casks/font-noto-sans-old-south-arabian.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-old-south-arabian' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansOldSouthArabian-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOldSouthArabian-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansOldSouthArabian-Regular.ttf'

--- a/Casks/font-noto-sans-old-turkic.rb
+++ b/Casks/font-noto-sans-old-turkic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-old-turkic' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansOldTurkic-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOldTurkic-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansOldTurkic-Regular.ttf'

--- a/Casks/font-noto-sans-osmanya.rb
+++ b/Casks/font-noto-sans-osmanya.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-osmanya' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansOsmanya-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOsmanya-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansOsmanya-Regular.ttf'

--- a/Casks/font-noto-sans-phags-pa.rb
+++ b/Casks/font-noto-sans-phags-pa.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-phags-pa' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansPhags-pa-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansPhags-pa-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansPhagsPa-Regular.ttf'

--- a/Casks/font-noto-sans-phoenician.rb
+++ b/Casks/font-noto-sans-phoenician.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-phoenician' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansPhoenician-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansPhoenician-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansPhoenician-Regular.ttf'

--- a/Casks/font-noto-sans-rejang.rb
+++ b/Casks/font-noto-sans-rejang.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-rejang' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansRejang-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansRejang-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansRejang-Regular.ttf'

--- a/Casks/font-noto-sans-runic.rb
+++ b/Casks/font-noto-sans-runic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-runic' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansRunic-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansRunic-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansRunic-Regular.ttf'

--- a/Casks/font-noto-sans-s-chinese.rb
+++ b/Casks/font-noto-sans-s-chinese.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-s-chinese' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.google.com/get/noto/pkgs/NotoSansCJKSC-hinted.zip'
-  homepage 'http://www.google.com/get/noto/#/family/noto-sans-hans'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKSC-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansCJKsc-Black.otf'

--- a/Casks/font-noto-sans-samaritan.rb
+++ b/Casks/font-noto-sans-samaritan.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-samaritan' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansSamaritan-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansSamaritan-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansSamaritan-Regular.ttf'

--- a/Casks/font-noto-sans-saurashtra.rb
+++ b/Casks/font-noto-sans-saurashtra.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-saurashtra' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansSaurashtra-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansSaurashtra-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansSaurashtra-Regular.ttf'

--- a/Casks/font-noto-sans-shavian.rb
+++ b/Casks/font-noto-sans-shavian.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-shavian' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansShavian-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansShavian-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansShavian-Regular.ttf'

--- a/Casks/font-noto-sans-sinhala.rb
+++ b/Casks/font-noto-sans-sinhala.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-sinhala' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansSinhala-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansSinhala-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansSinhala-Regular.ttf'

--- a/Casks/font-noto-sans-sumero-akkadian-cuneiform.rb
+++ b/Casks/font-noto-sans-sumero-akkadian-cuneiform.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-sumero-akkadian-cuneiform' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansSumero-AkkadianCuneiform-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansSumero-AkkadianCuneiform-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansSumeroAkkadianCuneiform-Regular.ttf'

--- a/Casks/font-noto-sans-sundanese.rb
+++ b/Casks/font-noto-sans-sundanese.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-sundanese' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansSundanese-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansSundanese-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansSundanese-Regular.ttf'

--- a/Casks/font-noto-sans-syloti-nagri.rb
+++ b/Casks/font-noto-sans-syloti-nagri.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-syloti-nagri' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansSylotiNagri-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansSylotiNagri-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansSylotiNagri-Regular.ttf'

--- a/Casks/font-noto-sans-symbols.rb
+++ b/Casks/font-noto-sans-symbols.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-symbols' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansSymbols-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansSymbols-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansSymbols-Regular.ttf'

--- a/Casks/font-noto-sans-syriac-eastern.rb
+++ b/Casks/font-noto-sans-syriac-eastern.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-syriac-eastern' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansSyriacEastern-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansSyriacEastern-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansSyriacEastern-Regular.ttf'

--- a/Casks/font-noto-sans-syriac-estrangela.rb
+++ b/Casks/font-noto-sans-syriac-estrangela.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-syriac-estrangela' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansSyriacEstrangela-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansSyriacEstrangela-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansSyriacEstrangela-Regular.ttf'

--- a/Casks/font-noto-sans-syriac-western.rb
+++ b/Casks/font-noto-sans-syriac-western.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-syriac-western' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansSyriacWestern-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansSyriacWestern-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansSyriacWestern-Regular.ttf'

--- a/Casks/font-noto-sans-t-chinese.rb
+++ b/Casks/font-noto-sans-t-chinese.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-t-chinese' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.google.com/get/noto/pkgs/NotoSansCJKTC-hinted.zip'
-  homepage 'http://www.google.com/get/noto/#/family/noto-sans-hant'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansCJKTC-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansCJKtc-Black.otf'

--- a/Casks/font-noto-sans-tagalog.rb
+++ b/Casks/font-noto-sans-tagalog.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-tagalog' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansTagalog-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansTagalog-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansTagalog-Regular.ttf'

--- a/Casks/font-noto-sans-tagbanwa.rb
+++ b/Casks/font-noto-sans-tagbanwa.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-tagbanwa' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansTagbanwa-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansTagbanwa-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansTagbanwa-Regular.ttf'

--- a/Casks/font-noto-sans-tai-le.rb
+++ b/Casks/font-noto-sans-tai-le.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-tai-le' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansTaiLe-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansTaiLe-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansTaiLe-Regular.ttf'

--- a/Casks/font-noto-sans-tai-tham.rb
+++ b/Casks/font-noto-sans-tai-tham.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-tai-tham' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansTaiTham-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansTaiTham-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansTaiTham-Regular.ttf'

--- a/Casks/font-noto-sans-tai-viet.rb
+++ b/Casks/font-noto-sans-tai-viet.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-tai-viet' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansTaiViet-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansTaiViet-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansTaiViet-Regular.ttf'

--- a/Casks/font-noto-sans-tamil.rb
+++ b/Casks/font-noto-sans-tamil.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-tamil' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansTamil-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansTamil-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansTamil-Bold.ttf'

--- a/Casks/font-noto-sans-telugu.rb
+++ b/Casks/font-noto-sans-telugu.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-telugu' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansTelugu-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansTelugu-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansTelugu-Regular.ttf'

--- a/Casks/font-noto-sans-thai.rb
+++ b/Casks/font-noto-sans-thai.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-thai' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansThai-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansThai-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansThai-Bold.ttf'

--- a/Casks/font-noto-sans-tifinagh.rb
+++ b/Casks/font-noto-sans-tifinagh.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-tifinagh' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansTifinagh-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansTifinagh-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansTifinagh-Regular.ttf'

--- a/Casks/font-noto-sans-ugaritic.rb
+++ b/Casks/font-noto-sans-ugaritic.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-ugaritic' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansUgaritic-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansUgaritic-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansUgaritic-Regular.ttf'

--- a/Casks/font-noto-sans-vai.rb
+++ b/Casks/font-noto-sans-vai.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-vai' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansVai-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansVai-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansVai-Regular.ttf'

--- a/Casks/font-noto-sans-yi.rb
+++ b/Casks/font-noto-sans-yi.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans-yi' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSansYi-unhinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansYi-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSansYi-Regular.ttf'

--- a/Casks/font-noto-sans.rb
+++ b/Casks/font-noto-sans.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-sans' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.google.com/get/noto/pkgs/NotoSans-unhinted.zip'
-  homepage 'http://www.google.com/get/noto/#/family/noto-sans'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSans-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSans-Bold.ttf'

--- a/Casks/font-noto-serif-armenian.rb
+++ b/Casks/font-noto-serif-armenian.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-serif-armenian' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSerifArmenian-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSerifArmenian-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSerifArmenian-Regular.ttf'

--- a/Casks/font-noto-serif-georgian.rb
+++ b/Casks/font-noto-serif-georgian.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-serif-georgian' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSerifGeorgian-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSerifGeorgian-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSerifGeorgian-Bold.ttf'

--- a/Casks/font-noto-serif-khmer.rb
+++ b/Casks/font-noto-serif-khmer.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-serif-khmer' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSerifKhmer-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSerifKhmer-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSerifKhmer-Bold.ttf'

--- a/Casks/font-noto-serif-lao.rb
+++ b/Casks/font-noto-serif-lao.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-serif-lao' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSerifLao-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSerifLao-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSerifLao-Bold.ttf'

--- a/Casks/font-noto-serif-thai.rb
+++ b/Casks/font-noto-serif-thai.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-serif-thai' do
   version :latest
   sha256 :no_check
 
-  url 'https://www.google.com/get/noto/pkgs/NotoSerifThai-hinted.zip'
-  homepage 'http://www.google.com/get/noto'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSerifThai-hinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSerifThai-Bold.ttf'

--- a/Casks/font-noto-serif.rb
+++ b/Casks/font-noto-serif.rb
@@ -2,8 +2,8 @@ cask :v1 => 'font-noto-serif' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.google.com/get/noto/pkgs/NotoSerif-unhinted.zip'
-  homepage 'http://www.google.com/get/noto/#/family/noto-serif'
+  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSerif-unhinted.zip'
+  homepage 'https://www.google.com/get/noto'
   license :apache
 
   font 'NotoSerif-Bold.ttf'


### PR DESCRIPTION
Changes made:
1. Use HTTPS protocol in all font-noto* Casks
2. Update homepage and use https://www.google.com/get/noto for all family fonts
3. Update URL of font files

This fixes #387