### PR TITLE
Add Indian Type Foundry fonts

### DIFF
--- a/Casks/font-halant.rb
+++ b/Casks/font-halant.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'font-halant' do
+  version '2.000'
+  sha256 'd65e1077b7c3d3ca42cf41f8ee2db4f6da5cc8aa6f615d18a1bb497f8e37ca63'
+
+  url 'https://github.com/itfoundry/halant/releases/download/v2.000/halant-2_000.zip'
+  appcast 'https://github.com/itfoundry/halant/releases.atom'
+  homepage 'https://github.com/itfoundry/halant'
+  license :ofl
+
+  font 'Halant-Bold.otf'
+  font 'Halant-Light.otf'
+  font 'Halant-Medium.otf'
+  font 'Halant-Regular.otf'
+  font 'Halant-SemiBold.otf'
+end

--- a/Casks/font-hind.rb
+++ b/Casks/font-hind.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'font-hind' do
+  version '2.000'
+  sha256 '8748ce1fa0db67d0c782d7824a9fdcf0b8544b9d063db477dff9733774571193'
+
+  url 'https://github.com/itfoundry/hind/releases/download/v2.000/hind-2_000.zip'
+  appcast 'https://github.com/itfoundry/hind/releases.atom'
+  homepage 'https://github.com/itfoundry/hind'
+  license :ofl
+
+  font 'Hind-Bold.otf'
+  font 'Hind-Light.otf'
+  font 'Hind-Medium.otf'
+  font 'Hind-Regular.otf'
+  font 'Hind-SemiBold.otf'
+end

--- a/Casks/font-kalam.rb
+++ b/Casks/font-kalam.rb
@@ -1,0 +1,13 @@
+cask :v1 => 'font-kalam' do
+  version '2.000'
+  sha256 '6b97c9719e7eaf3c069610059b548c2e130240d9996ec73ab61cfb17f1cbd1e6'
+
+  url 'https://github.com/itfoundry/kalam/releases/download/v2.000/kalam-2_000.zip'
+  appcast 'https://github.com/itfoundry/kalam/releases.atom'
+  homepage 'https://github.com/itfoundry/kalam'
+  license :ofl
+
+  font 'Kalam-Bold.otf'
+  font 'Kalam-Light.otf'
+  font 'Kalam-Regular.otf'
+end

--- a/Casks/font-karma.rb
+++ b/Casks/font-karma.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'font-karma' do
+  version '2.000'
+  sha256 'ebbe01be41c18aed6e538ea8d88eec65bb1bca046afc36b2fc6a84e808bda7e4'
+
+  url 'https://github.com/itfoundry/karma/releases/download/v2.000/karma-2_000.zip'
+  appcast 'https://github.com/itfoundry/karma/releases.atom'
+  homepage 'https://github.com/itfoundry/karma'
+  license :ofl
+
+  font 'Karma-Bold.otf'
+  font 'Karma-Light.otf'
+  font 'Karma-Medium.otf'
+  font 'Karma-Regular.otf'
+  font 'Karma-SemiBold.otf'
+end

--- a/Casks/font-khand.rb
+++ b/Casks/font-khand.rb
@@ -1,0 +1,18 @@
+cask :v1 => 'font-khand' do
+  version '2.000'
+  sha256 '668910b4cd3487a5bbf93f6dd7259914c1596eec7fef28b08877abdbb7775226'
+
+  url 'https://github.com/itfoundry/khand/releases/download/v2.000/khand-2_000.zip'
+  appcast 'https://github.com/itfoundry/khand/releases.atom'
+  homepage 'https://github.com/itfoundry/khand'
+  license :ofl
+
+  font 'Khand-Black.otf'
+  font 'Khand-Bold.otf'
+  font 'Khand-ExtraBold.otf'
+  font 'Khand-ExtraLight.otf'
+  font 'Khand-Light.otf'
+  font 'Khand-Regular.otf'
+  font 'Khand-SemiBold.otf'
+  font 'Khand-SemiLight.otf'
+end

--- a/Casks/font-laila.rb
+++ b/Casks/font-laila.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'font-laila' do
+  version '2.000'
+  sha256 'caa87cae373702288a7510c74881077aa15e3b5c94a4746b61f3f977d8499f73'
+
+  url 'https://github.com/itfoundry/laila/releases/download/v2.000/laila-2_000.zip'
+  appcast 'https://github.com/itfoundry/laila/releases.atom'
+  homepage 'https://github.com/itfoundry/laila'
+  license :ofl
+
+  font 'Laila-Bold.otf'
+  font 'Laila-Light.otf'
+  font 'Laila-Medium.otf'
+  font 'Laila-Regular.otf'
+  font 'Laila-SemiBold.otf'
+end

--- a/Casks/font-poppins.rb
+++ b/Casks/font-poppins.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'font-poppins' do
+  version '2.000'
+  sha256 '86f53a3d50baaadca0d7a1aaf4d69e4d8d3a3d8a9fe67bc3d9b0c0db000e0f39'
+
+  url 'https://github.com/itfoundry/poppins/releases/download/v2.000/poppins-2_000.zip'
+  appcast 'https://github.com/itfoundry/poppins/releases.atom'
+  homepage 'https://github.com/itfoundry/poppins'
+  license :ofl
+
+  font 'Poppins-Bold.otf'
+  font 'Poppins-Light.otf'
+  font 'Poppins-Medium.otf'
+  font 'Poppins-Regular.otf'
+  font 'Poppins-SemiBold.otf'
+end

--- a/Casks/font-rajdhani.rb
+++ b/Casks/font-rajdhani.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'font-rajdhani' do
+  version '2.000'
+  sha256 '2dd0b14ed9989319fde8518e4b596467ae635571ffe7733d7968201d8cdeb9cf'
+
+  url 'https://github.com/itfoundry/rajdhani/releases/download/v2.000/rajdhani-2_000.zip'
+  appcast 'https://github.com/itfoundry/rajdhani/releases.atom'
+  homepage 'https://github.com/itfoundry/rajdhani'
+  license :ofl
+
+  font 'Rajdhani-Bold.otf'
+  font 'Rajdhani-Light.otf'
+  font 'Rajdhani-Medium.otf'
+  font 'Rajdhani-Regular.otf'
+  font 'Rajdhani-SemiBold.otf'
+end

--- a/Casks/font-rozha-one.rb
+++ b/Casks/font-rozha-one.rb
@@ -1,0 +1,11 @@
+cask :v1 => 'font-rozha-one' do
+  version '2.000'
+  sha256 '9048def2a602b51466f6f7528a0e83fbc73abd72aadb87d70fba3887e6101c7c'
+
+  url 'https://github.com/itfoundry/rozhaone/releases/download/v2.000/rozhaone-2_000.zip'
+  appcast 'https://github.com/itfoundry/rozhaone/releases.atom'
+  homepage 'https://github.com/itfoundry/rozhaone'
+  license :ofl
+
+  font 'RozhaOne-Regular.otf'
+end

--- a/Casks/font-sarpanch.rb
+++ b/Casks/font-sarpanch.rb
@@ -1,0 +1,16 @@
+cask :v1 => 'font-sarpanch' do
+  version '2.000'
+  sha256 '5da058f7a7686ea5ad9d2811b2063343a580bf4da3d415a947d2c37d6c5bcf07'
+
+  url 'https://github.com/itfoundry/sarpanch/releases/download/v2.000/sarpanch-2_000.zip'
+  appcast 'https://github.com/itfoundry/sarpanch/releases.atom'
+  homepage 'https://github.com/itfoundry/sarpanch'
+  license :ofl
+
+  font 'Sarpanch-Black.otf'
+  font 'Sarpanch-Bold.otf'
+  font 'Sarpanch-ExtraBold.otf'
+  font 'Sarpanch-Medium.otf'
+  font 'Sarpanch-Regular.otf'
+  font 'Sarpanch-SemiBold.otf'
+end

--- a/Casks/font-teko.rb
+++ b/Casks/font-teko.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'font-teko' do
+  version '2.000'
+  sha256 '189cfd7d5f75ef206da039795574a0e66cf2daa3d1b31405c0fda7d70e6ac802'
+
+  url 'https://github.com/itfoundry/teko/releases/download/v2.000/teko-2_000.zip'
+  appcast 'https://github.com/itfoundry/teko/releases.atom'
+  homepage 'https://github.com/itfoundry/teko'
+  license :ofl
+
+  font 'Teko-Bold.otf'
+  font 'Teko-Light.otf'
+  font 'Teko-Medium.otf'
+  font 'Teko-Regular.otf'
+  font 'Teko-SemiBold.otf'
+end

--- a/Casks/font-tillana.rb
+++ b/Casks/font-tillana.rb
@@ -1,0 +1,15 @@
+cask :v1 => 'font-tillana' do
+  version '2.000'
+  sha256 '26e3926523f8bc63ee344a4d1957b8bbbed55c721103a88fa9b1a678f4761e08'
+
+  url 'https://github.com/itfoundry/tillana/releases/download/v2.000/tillana-2_000.zip'
+  appcast 'https://github.com/itfoundry/tillana/releases.atom'
+  homepage 'https://github.com/itfoundry/tillana'
+  license :ofl
+
+  font 'Tillana-Bold.otf'
+  font 'Tillana-ExtraBold.otf'
+  font 'Tillana-Medium.otf'
+  font 'Tillana-Regular.otf'
+  font 'Tillana-SemiBold.otf'
+end


### PR DESCRIPTION
Add the following fonts from Indian Type Foundry:
- Halant
- Hind
- Kalam
- Karma
- Khand
- Laila
- Poppins
- Rajdhani
- Rozha One
- Sarpanch
- Teko
- Tillana