### PR TITLE
Add the Octicons font

### DIFF
--- a/Casks/font-octicons.rb
+++ b/Casks/font-octicons.rb
@@ -1,0 +1,10 @@
+cask :v1 => 'font-octicons' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://github.com/github/octicons/archive/master.zip'
+  homepage 'https://octicons.github.com'
+  license :ofl
+
+  font 'octicons-master/octicons/octicons-local.ttf'
+end


### PR DESCRIPTION
This adds GitHub's Octicons font to Homebrew, literally, the only font I use which isn't already part of the cask.

To note, it will install off of `master`, not truly the latest release.

Fixes https://github.com/github/octicons/issues/70. 

/cc @cameronmcefee
