### PR TITLE
Fix outdated Roboto versions

### DIFF
--- a/Casks/font-roboto-condensed.rb
+++ b/Casks/font-roboto-condensed.rb
@@ -1,0 +1,17 @@
+cask :v1 => 'font-roboto-condensed' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://github.com/google/fonts/trunk/apache/robotocondensed',
+      :using      => :svn,
+      :trust_cert => true
+  homepage 'http://www.google.com/fonts/specimen/Roboto%20Condensed'
+  license :apache
+
+  font 'RobotoCondensed-Bold.ttf'
+  font 'RobotoCondensed-BoldItalic.ttf'
+  font 'RobotoCondensed-Italic.ttf'
+  font 'RobotoCondensed-Light.ttf'
+  font 'RobotoCondensed-LightItalic.ttf'
+  font 'RobotoCondensed-Regular.ttf'
+end

--- a/Casks/font-roboto-mono.rb
+++ b/Casks/font-roboto-mono.rb
@@ -1,10 +1,11 @@
 cask :v1 => 'font-roboto-mono' do
-  # version '2.000985'
   version :latest
   sha256 :no_check
-  
-  url 'https://www.google.com/fonts/download?kit=rqQ1zSE-ZGCKVZgew-A9dofD-WQWLbF4rYwcBGowFYY'
-  homepage 'https://www.google.com/fonts/specimen/Roboto+Mono'
+
+  url 'https://github.com/google/fonts/trunk/apache/robotomono',
+      :using      => :svn,
+      :trust_cert => true
+  homepage 'http://www.google.com/fonts/specimen/Roboto%20Mono'
   license :apache
 
   font 'RobotoMono-Bold.ttf'

--- a/Casks/font-roboto-slab.rb
+++ b/Casks/font-roboto-slab.rb
@@ -1,11 +1,9 @@
 cask :v1 => 'font-roboto-slab' do
-  # version '1.100263'
   version :latest
   sha256 :no_check
 
   url 'https://github.com/google/fonts/trunk/apache/robotoslab',
       :using      => :svn,
-      :revision   => '50',
       :trust_cert => true
   homepage 'http://www.google.com/fonts/specimen/Roboto%20Slab'
   license :apache

--- a/Casks/font-roboto.rb
+++ b/Casks/font-roboto.rb
@@ -1,27 +1,23 @@
 cask :v1 => 'font-roboto' do
-  version '1.200311'
-  sha256 '5101b5bdb3b7b14cc922a771ba068bfcae8634467c1f446bc89bc2b4f8b4f1b5'
+  version :latest
+  sha256 :no_check
 
-  url 'http://developer.android.com/downloads/design/roboto-1.2.zip'
-  homepage 'http://developer.android.com/design/style/typography.html'
+  url 'https://github.com/google/fonts/trunk/apache/roboto',
+      :using      => :svn,
+      :trust_cert => true
+  homepage 'http://www.google.com/fonts/specimen/Roboto'
   license :apache
 
-  font 'Roboto_v1.2/Roboto/Roboto-Black.ttf'
-  font 'Roboto_v1.2/Roboto/Roboto-BlackItalic.ttf'
-  font 'Roboto_v1.2/Roboto/Roboto-Bold.ttf'
-  font 'Roboto_v1.2/Roboto/Roboto-BoldItalic.ttf'
-  font 'Roboto_v1.2/Roboto/Roboto-Italic.ttf'
-  font 'Roboto_v1.2/Roboto/Roboto-Light.ttf'
-  font 'Roboto_v1.2/Roboto/Roboto-LightItalic.ttf'
-  font 'Roboto_v1.2/Roboto/Roboto-Medium.ttf'
-  font 'Roboto_v1.2/Roboto/Roboto-MediumItalic.ttf'
-  font 'Roboto_v1.2/Roboto/Roboto-Regular.ttf'
-  font 'Roboto_v1.2/Roboto/Roboto-Thin.ttf'
-  font 'Roboto_v1.2/Roboto/Roboto-ThinItalic.ttf'
-  font 'Roboto_v1.2/RobotoCondensed/RobotoCondensed-Bold.ttf'
-  font 'Roboto_v1.2/RobotoCondensed/RobotoCondensed-BoldItalic.ttf'
-  font 'Roboto_v1.2/RobotoCondensed/RobotoCondensed-Italic.ttf'
-  font 'Roboto_v1.2/RobotoCondensed/RobotoCondensed-Light.ttf'
-  font 'Roboto_v1.2/RobotoCondensed/RobotoCondensed-LightItalic.ttf'
-  font 'Roboto_v1.2/RobotoCondensed/RobotoCondensed-Regular.ttf'
+  font 'Roboto-Black.ttf'
+  font 'Roboto-BlackItalic.ttf'
+  font 'Roboto-Bold.ttf'
+  font 'Roboto-BoldItalic.ttf'
+  font 'Roboto-Italic.ttf'
+  font 'Roboto-Light.ttf'
+  font 'Roboto-LightItalic.ttf'
+  font 'Roboto-Medium.ttf'
+  font 'Roboto-MediumItalic.ttf'
+  font 'Roboto-Regular.ttf'
+  font 'Roboto-Thin.ttf'
+  font 'Roboto-ThinItalic.ttf'
 end


### PR DESCRIPTION
Current source for font-roboto is v1.200311, which is noticeably different than the current v2.0+. Updated to download the latest versions from the official https://github.com/google/fonts repository