### PR TITLE
Restore font-symbola with newer version

### DIFF
--- a/Casks/font-symbola.rb
+++ b/Casks/font-symbola.rb
@@ -1,0 +1,11 @@
+cask 'font-symbola' do
+  # version '8.00'
+  version :latest
+  sha256 :no_check
+
+  url 'http://users.teilar.gr/~g1951d/Symbola.zip'
+  homepage 'http://users.teilar.gr/~g1951d/'
+  license :gratis
+
+  font 'Symbola_hint.ttf'
+end


### PR DESCRIPTION
Symbola is available again on the author home page.

License, home page URL, and archive URL remain the same.

Version increased to 8.0.0.