### PR TITLE
Add italic variants to Hasklig

### DIFF
--- a/Casks/font-hasklig.rb
+++ b/Casks/font-hasklig.rb
@@ -9,10 +9,17 @@ cask 'font-hasklig' do
   license :ofl
 
   font 'Hasklig-Black.otf'
+  font 'Hasklig-BlackIt.otf'
   font 'Hasklig-Bold.otf'
+  font 'Hasklig-BoldIt.otf'
   font 'Hasklig-ExtraLight.otf'
+  font 'Hasklig-ExtraLightIt.otf'
+  font 'Hasklig-It.otf'
   font 'Hasklig-Light.otf'
+  font 'Hasklig-LightIt.otf'
   font 'Hasklig-Medium.otf'
+  font 'Hasklig-MediumIt.otf'
   font 'Hasklig-Regular.otf'
   font 'Hasklig-Semibold.otf'
+  font 'Hasklig-SemiboldIt.otf'
 end


### PR DESCRIPTION
The 0.9 release introduced italics, which I omitted to include earlier. :(