### PR TITLE
.travis.yml: remove 10.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ matrix:
       os: osx
       osx_image: xcode7.1
       rvm: system
-    - env: OSX=10.9 HOMEBREW_RUBY=2.0.0
-      os: osx
-      osx_image: beta-xcode6.2
-      rvm: system
   fast_finish: true
 
 branches:


### PR DESCRIPTION
To merge only if https://github.com/caskroom/homebrew-cask/pull/19475 is merged.