### PR TITLE
Update fontawesome to 4.6.0

### DIFF
--- a/Casks/font-fontawesome.rb
+++ b/Casks/font-fontawesome.rb
@@ -1,11 +1,11 @@
 cask 'font-fontawesome' do
-  version '4.5.0'
-  sha256 '6eb9dd94a87ebe10e75acb78a75530ccb33bb60a3b28d0a2c72f14fceecca18a'
+  version '4.6.0'
+  sha256 '4f9b528e02e90e24782383050ae5b69c9a73de1734796bf8763ee2d3a128c8ac'
 
   url "https://fortawesome.github.io/Font-Awesome/assets/font-awesome-#{version}.zip"
   name 'Font Awesome'
   homepage 'http://fortawesome.github.io/Font-Awesome/'
   license :oss
 
-  font "Font-Awesome-#{version}/fonts/FontAwesome.otf"
+  font "font-awesome-#{version}/fonts/FontAwesome.otf"
 end


### PR DESCRIPTION
Looks like the folks over at FortAwesome pushed an update a few hours back that breaks the `font-fontawesome` cask. Hopefully this fixes it, but I'm not 100% sure I'm using the `font_casker` utility correctly, so I'd appreciate it if someone could verify the SHA256 value? Thanks!