### PR TITLE
Update font-fontawesome.rb

### DIFF
--- a/Casks/font-fontawesome.rb
+++ b/Casks/font-fontawesome.rb
@@ -2,7 +2,7 @@ cask 'font-fontawesome' do
   version '4.5.0'
   sha256 '6eb9dd94a87ebe10e75acb78a75530ccb33bb60a3b28d0a2c72f14fceecca18a'
 
-  url "https://fortawesome.github.io/Font-Awesome/assets/font-awesome-#{version}.zip"
+  url "https://github.com/FortAwesome/Font-Awesome/archive/v#{version}.zip"
   name 'Font Awesome'
   homepage 'http://fortawesome.github.io/Font-Awesome/'
   license :oss


### PR DESCRIPTION
Retrieve the file from the github releases page, not the assets to the github-hosted project page.

With the release of version 4.6, the 4.5 zip file is missing from 

`https://fortawesome.github.io/Font-Awesome/assets/font-awesome-4.5.0.zip` 

but still exists at 

`https://github.com/FortAwesome/Font-Awesome/archive/v#{version}.zip`