### PR TITLE
Add font-mfizz

### DIFF
--- a/Casks/font-fontmfizz.rb
+++ b/Casks/font-fontmfizz.rb
@@ -1,0 +1,12 @@
+cask 'font-mfizz' do
+  version '2.3.0'
+  sha256 '40284c1f095902e7d2ac043713b6051c62b729e115e32806dade2ea10aad817a'
+
+  # github.com was verified as official when first introduced to the cask
+  url "https://github.com/fizzed/font-mfizz/releases/download/v2.3.0/font-mfizz-#{version}.zip"
+  name 'Font Mfizz'
+  homepage 'http://fizzed.com/oss/font-mfizz'
+  license :mit
+
+  font "font-mfizz-#{version}/font-mfizz.ttf"
+end

--- a/Casks/font-mfizz.rb
+++ b/Casks/font-mfizz.rb
@@ -1,0 +1,12 @@
+cask 'font-fontmfizz' do
+  version '2.3.0'
+  sha256 '40284c1f095902e7d2ac043713b6051c62b729e115e32806dade2ea10aad817a'
+
+  # github.com was verified as official when first introduced to the cask
+  url "https://github.com/fizzed/font-mfizz/releases/download/v2.3.0/font-mfizz-#{version}.zip"
+  name 'Font Mfizz'
+  homepage 'http://fizzed.com/oss/font-mfizz'
+  license :mit
+
+  font "font-mfizz-#{version}/font-mfizz.ttf"
+end


### PR DESCRIPTION
- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-fonts/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-fonts/issues) where that cask was already refused.
- [x] When naming the cask, followed the [reference](https://github.com/caskroom/homebrew-fonts/blob/master/CONTRIBUTING.md#naming-font-casks).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` left no offenses. Not able to install `rubocop-cask' at this time.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

