### PR TITLE
Updated font-hack font version to 2.020

### DIFF
--- a/Casks/font-hack.rb
+++ b/Casks/font-hack.rb
@@ -1,6 +1,6 @@
 cask 'font-hack' do
-  version '2.019'
-  sha256 '9e847ad7afb327ca089c4b09d1368091ca0c98e64a2fe284755162e6650bfdd2'
+  version '2.020'
+  sha256 '88f7124c0aa8b0ba3e38142f16fae2d1fcab4f2b3fcc9152f403de325dc4876c'
 
   # github.com/chrissimpkins/Hack was verified as official when first introduced to the cask
   url "https://github.com/chrissimpkins/Hack/archive/v#{version}.zip"

--- a/Casks/font-hack.rb
+++ b/Casks/font-hack.rb
@@ -5,7 +5,7 @@ cask 'font-hack' do
   # github.com/chrissimpkins/Hack was verified as official when first introduced to the cask
   url "https://github.com/chrissimpkins/Hack/archive/v#{version}.zip"
   appcast 'https://github.com/chrissimpkins/Hack/releases.atom',
-          checkpoint: 'a674ef1ff633112e83b25ac3d4f260f846c61c26d5c981c228e49ad1e9706369'
+          checkpoint: 'fccba3ddfc4b50a011498f4a8f5956758421ae96725ce54f7f9fac97fd5161d1'
   name 'Hack'
   homepage 'http://sourcefoundry.org/hack/'
   license :ofl


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.



