### PR TITLE
SuperOTC format for font-source-han-sans

### DIFF
--- a/Casks/font-source-han-sans.rb
+++ b/Casks/font-source-han-sans.rb
@@ -1,4 +1,4 @@
-sk 'font-source-han-sans' do
+Cask 'font-source-han-sans' do
   version '1.004'
   sha256 'b684c9b659ec4998e72d22ff5ed3f531d31d506ae00a48ec72b9846be23e7c10'
 

--- a/Casks/font-source-han-sans.rb
+++ b/Casks/font-source-han-sans.rb
@@ -1,4 +1,4 @@
-Cask 'font-source-han-sans' do
+cask 'font-source-han-sans' do
   version '1.004'
   sha256 'b684c9b659ec4998e72d22ff5ed3f531d31d506ae00a48ec72b9846be23e7c10'
 

--- a/Casks/font-source-han-sans.rb
+++ b/Casks/font-source-han-sans.rb
@@ -1,37 +1,10 @@
-cask 'font-source-han-sans' do
+sk 'font-source-han-sans' do
   version '1.004'
-  sha256 '3581236fd7a59bbc95e1bc2fa7fabbf7c47b05f0363d170b5bf08098de33007c'
+  sha256 'b684c9b659ec4998e72d22ff5ed3f531d31d506ae00a48ec72b9846be23e7c10'
 
-  url "https://github.com/adobe-fonts/source-han-sans/archive/#{version}R.zip"
+  url 'https://github.com/adobe-fonts/source-han-sans/raw/5f5311e71cb628321cc0cffb51fb38d862b726aa/SuperOTC/SourceHanSans.ttc.zip'
   homepage 'https://github.com/adobe-fonts/source-han-sans'
-  license :oss
+  license :ofl
 
-  font "source-han-sans-#{version}R/OTF/Japanese/SourceHanSans-Bold.otf"
-  font "source-han-sans-#{version}R/OTF/Japanese/SourceHanSans-ExtraLight.otf"
-  font "source-han-sans-#{version}R/OTF/Japanese/SourceHanSans-Heavy.otf"
-  font "source-han-sans-#{version}R/OTF/Japanese/SourceHanSans-Light.otf"
-  font "source-han-sans-#{version}R/OTF/Japanese/SourceHanSans-Medium.otf"
-  font "source-han-sans-#{version}R/OTF/Japanese/SourceHanSans-Normal.otf"
-  font "source-han-sans-#{version}R/OTF/Japanese/SourceHanSans-Regular.otf"
-  font "source-han-sans-#{version}R/OTF/Korean/SourceHanSansK-Bold.otf"
-  font "source-han-sans-#{version}R/OTF/Korean/SourceHanSansK-ExtraLight.otf"
-  font "source-han-sans-#{version}R/OTF/Korean/SourceHanSansK-Heavy.otf"
-  font "source-han-sans-#{version}R/OTF/Korean/SourceHanSansK-Light.otf"
-  font "source-han-sans-#{version}R/OTF/Korean/SourceHanSansK-Medium.otf"
-  font "source-han-sans-#{version}R/OTF/Korean/SourceHanSansK-Normal.otf"
-  font "source-han-sans-#{version}R/OTF/Korean/SourceHanSansK-Regular.otf"
-  font "source-han-sans-#{version}R/OTF/SimplifiedChinese/SourceHanSansSC-Bold.otf"
-  font "source-han-sans-#{version}R/OTF/SimplifiedChinese/SourceHanSansSC-ExtraLight.otf"
-  font "source-han-sans-#{version}R/OTF/SimplifiedChinese/SourceHanSansSC-Heavy.otf"
-  font "source-han-sans-#{version}R/OTF/SimplifiedChinese/SourceHanSansSC-Light.otf"
-  font "source-han-sans-#{version}R/OTF/SimplifiedChinese/SourceHanSansSC-Medium.otf"
-  font "source-han-sans-#{version}R/OTF/SimplifiedChinese/SourceHanSansSC-Normal.otf"
-  font "source-han-sans-#{version}R/OTF/SimplifiedChinese/SourceHanSansSC-Regular.otf"
-  font "source-han-sans-#{version}R/OTF/TraditionalChinese/SourceHanSansTC-Bold.otf"
-  font "source-han-sans-#{version}R/OTF/TraditionalChinese/SourceHanSansTC-ExtraLight.otf"
-  font "source-han-sans-#{version}R/OTF/TraditionalChinese/SourceHanSansTC-Heavy.otf"
-  font "source-han-sans-#{version}R/OTF/TraditionalChinese/SourceHanSansTC-Light.otf"
-  font "source-han-sans-#{version}R/OTF/TraditionalChinese/SourceHanSansTC-Medium.otf"
-  font "source-han-sans-#{version}R/OTF/TraditionalChinese/SourceHanSansTC-Normal.otf"
-  font "source-han-sans-#{version}R/OTF/TraditionalChinese/SourceHanSansTC-Regular.otf"
+  font 'SourceHanSans.ttc'
 end

--- a/Casks/font-source-han-sans.rb
+++ b/Casks/font-source-han-sans.rb
@@ -4,6 +4,7 @@ cask 'font-source-han-sans' do
 
   url 'https://github.com/adobe-fonts/source-han-sans/raw/5f5311e71cb628321cc0cffb51fb38d862b726aa/SuperOTC/SourceHanSans.ttc.zip'
   homepage 'https://github.com/adobe-fonts/source-han-sans'
+  name "Source Han Sans"
   license :ofl
 
   font 'SourceHanSans.ttc'


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free. **[FIXED]**
- [x] `brew cask style --fix {{cask_file}}` left no offenses. 

------
See #519. 