### PR TITLE
Fix font-koruri install font file paths

### DIFF
--- a/Casks/font-koruri.rb
+++ b/Casks/font-koruri.rb
@@ -10,9 +10,9 @@ cask 'font-koruri' do
   homepage 'http://koruri.lindwurm.biz/'
   license :apache
 
-  font "Koruri-#{version}/Koruri-Bold.ttf"
-  font "Koruri-#{version}/Koruri-Extrabold.ttf"
-  font "Koruri-#{version}/Koruri-Light.ttf"
-  font "Koruri-#{version}/Koruri-Regular.ttf"
-  font "Koruri-#{version}/Koruri-Semibold.ttf"
+  font "Koruri-#{version.before_comma}/Koruri-Bold.ttf"
+  font "Koruri-#{version.before_comma}/Koruri-Extrabold.ttf"
+  font "Koruri-#{version.before_comma}/Koruri-Light.ttf"
+  font "Koruri-#{version.before_comma}/Koruri-Regular.ttf"
+  font "Koruri-#{version.before_comma}/Koruri-Semibold.ttf"
 end


### PR DESCRIPTION
fix issue of can't install font-koruri.
missing ".before_comma"

#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.