### PR TITLE
Update url for font-fjalla-one

### DIFF
--- a/Casks/font-fjalla-one.rb
+++ b/Casks/font-fjalla-one.rb
@@ -3,6 +3,7 @@ cask 'font-fjalla-one' do
   sha256 '2c4a287ae4d7e6dbf6e45b6264612d02130147dcd5434cf168a1ba83055225bf'
 
   url 'https://github.com/google/fonts/raw/a30ff88e1a02d70aaf2589dfc3cef18a4128c495/ofl/fjallaone/FjallaOne-Regular.ttf'
+  name 'Fjalla One'
   homepage 'http://www.google.com/fonts/specimen/Fjalla%20One'
   license :ofl
 

--- a/Casks/font-fjalla-one.rb
+++ b/Casks/font-fjalla-one.rb
@@ -2,7 +2,7 @@ cask 'font-fjalla-one' do
   version '1.001'
   sha256 '2c4a287ae4d7e6dbf6e45b6264612d02130147dcd5434cf168a1ba83055225bf'
 
-  url 'https://googlefontdirectory.googlecode.com/hg-history/67342bc472599b4c32201ee4a002fe59a6447a42/ofl/fjallaone/FjallaOne-Regular.ttf'
+  url 'https://github.com/google/fonts/raw/a30ff88e1a02d70aaf2589dfc3cef18a4128c495/ofl/fjallaone/FjallaOne-Regular.ttf'
   homepage 'http://www.google.com/fonts/specimen/Fjalla%20One'
   license :ofl
 


### PR DESCRIPTION
I updated the URL for `font-fjalla-one` because the old one wasn't working.

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

Audit fails with:

```
audit for font-fjalla-one: failed
 - at least one name stanza is required
```

Since I didn't make significant changes, I can't imagine this was caused by this PR.