### PR TITLE
font-input: Use default lineHeight 1.2

### DIFF
--- a/Casks/font-input.rb
+++ b/Casks/font-input.rb
@@ -4,7 +4,7 @@ cask 'font-input' do
 
   # the served font is built dynamically, according to the query string;
   # we pass the default parameters, plus the required license agreement.
-  url 'http://input.fontbureau.com/build/?basic=1&fontSelection=whole&a=0&g=0&i=0&l=0&zero=0&asterisk=0&lineHeight=1&accept=I+do'
+  url 'http://input.fontbureau.com/build/?basic=1&fontSelection=whole&a=0&g=0&i=0&l=0&zero=0&asterisk=0&lineHeight=1.2&accept=I+do'
   homepage 'http://input.fontbureau.com/'
   license :closed
 

--- a/Casks/font-input.rb
+++ b/Casks/font-input.rb
@@ -5,6 +5,7 @@ cask 'font-input' do
   # the served font is built dynamically, according to the query string;
   # we pass the default parameters, plus the required license agreement.
   url 'http://input.fontbureau.com/build/?basic=1&fontSelection=whole&a=0&g=0&i=0&l=0&zero=0&asterisk=0&lineHeight=1.2&accept=I+do'
+  name 'Input'
   homepage 'http://input.fontbureau.com/'
   license :closed
 


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download https://raw.githubusercontent.com/anderscarling/homebrew-fonts/patch-1/Casks/font-input.rb` is error-free.
- [x] `brew cask style --fix font-input.rb` left no offenses.

* http://input.fontbureau.com/download/ actually defaults to 1.2
* Also added missing name sanza as required by `brew cask audit`