### PR TITLE
fix octicons

### DIFF
--- a/Casks/font-octicons.rb
+++ b/Casks/font-octicons.rb
@@ -3,6 +3,7 @@ cask 'font-octicons' do
   sha256 :no_check
 
   url 'https://github.com/github/octicons/archive/master.zip'
+  name 'octicons'
   homepage 'https://octicons.github.com'
   license :ofl
 

--- a/Casks/font-octicons.rb
+++ b/Casks/font-octicons.rb
@@ -6,5 +6,5 @@ cask 'font-octicons' do
   homepage 'https://octicons.github.com'
   license :ofl
 
-  font 'octicons-master/octicons/octicons-local.ttf'
+  font 'octicons-master/build/font/octicons.ttf'
 end


### PR DESCRIPTION
The octicons font was broken. This should fix it.

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.