### PR TITLE
Added Noto Sans CJK All-in-One.

### DIFF
--- a/Casks/font-noto-sans-cjk.rb
+++ b/Casks/font-noto-sans-cjk.rb
@@ -1,0 +1,11 @@
+cask 'font-noto-sans-cjk' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJK.ttc.zip'
+  name 'Noto Sans CJK'
+  homepage 'https://www.google.com/get/noto/help/cjk/'
+  license :ofl
+
+  font 'NotoSansCJK.ttc'
+end

--- a/Casks/font-noto-sans-cjk.rb
+++ b/Casks/font-noto-sans-cjk.rb
@@ -2,6 +2,7 @@ cask 'font-noto-sans-cjk' do
   version :latest
   sha256 :no_check
 
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
   url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJK.ttc.zip'
   name 'Noto Sans CJK'
   homepage 'https://www.google.com/get/noto/help/cjk/'


### PR DESCRIPTION
As https://www.google.com/get/noto/help/cjk/ suggested, the all-in-one package is recommended in Mac OS X 10.8 or above instead of using the `font-noto-sans-cjk-*.rb`.

### Changes to a cask
#### Adding a new cask

- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-fonts/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-fonts/issues) where that cask was already refused.
- [x] When naming the cask, followed the [reference](https://github.com/caskroom/homebrew-fonts/blob/master/CONTRIBUTING.md#naming-font-casks).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

