### PR TITLE
Add font-et-book

### DIFF
--- a/Casks/font-et-book.rb
+++ b/Casks/font-et-book.rb
@@ -1,0 +1,21 @@
+cask 'font-et-book' do
+  # version '001.001'
+  version :latest
+  sha256 :no_check
+
+  # github.com/edwardtufte/et-book was verified as official when first introduced to the cask
+  url 'https://github.com/edwardtufte/et-book/trunk/et-book',
+      using:      :svn,
+      revision:   '50',
+      trust_cert: true
+  name 'ET Book'
+  name 'Edward Tufte Book'
+  homepage 'http://edwardtufte.github.io/et-book/'
+  license :mit
+
+  font 'et-book-bold-line-figures/et-book-bold-line-figures.ttf'
+  font 'et-book-display-italic-old-style-figures/et-book-display-italic-old-style-figures.ttf'
+  font 'et-book-roman-line-figures/et-book-roman-line-figures.ttf'
+  font 'et-book-roman-old-style-figures/et-book-roman-old-style-figures.ttf'
+  font 'et-book-semi-bold-old-style-figures/et-book-semi-bold-old-style-figures.ttf'
+end


### PR DESCRIPTION
#### Adding a new cask

- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-fonts/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-fonts/issues) where that cask was already refused.
- [x] When naming the cask, followed the [reference](https://github.com/caskroom/homebrew-fonts/blob/master/CONTRIBUTING.md#naming-font-casks).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.

  I'm getting the following error that I don't know how to fix (help is appreciated):

  ```
$ brew cask audit --download font-et-book
Already downloaded: /Users/leafac/Library/Caches/Homebrew/font-et-book--svn-latest.tar
==> No checksum defined for Cask font-et-book, skipping verification
audit for font-et-book: failed
 - at least one name stanza is required
Error: audit failed
  ```

  Note: I based this on `font-cuprum`, which fails with exactly the same error.

- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

