### PR TITLE
Add font-materialdesignicons-webfont.

### DIFF
--- a/Casks/font-materialdesignicons-webfont.rb
+++ b/Casks/font-materialdesignicons-webfont.rb
@@ -1,0 +1,16 @@
+cask 'font-materialdesignicons-webfont' do
+  # version '1.6.50'
+  version :latest
+  sha256 :no_check
+
+  # github.com/templarian/materialdesign-webfont/trunk/fonts was verified as offical when first introduced to the cask
+  url 'https://github.com/templarian/materialdesign-webfont/trunk/fonts',
+      using:      :svn,
+      revision:   '50',
+      trust_cert: true
+  name 'Material Design Icons Webfont'
+  homepage 'https://materialdesignicons.com'
+  license :ofl
+
+  font 'materialdesignicons-webfont.ttf'
+end

--- a/Casks/font-materialdesignicons-webfont.rb
+++ b/Casks/font-materialdesignicons-webfont.rb
@@ -3,7 +3,7 @@ cask 'font-materialdesignicons-webfont' do
   version :latest
   sha256 :no_check
 
-  # github.com/templarian/materialdesign-webfont/trunk/fonts was verified as offical when first introduced to the cask
+  # github.com/templarian/materialdesign-webfont was verified as offical when first introduced to the cask
   url 'https://github.com/templarian/materialdesign-webfont/trunk/fonts',
       using:      :svn,
       revision:   '50',


### PR DESCRIPTION
#### Adding a new cask

- [x] Checked there aren’t open [pull requests](https://github.com/caskroom/homebrew-fonts/pulls) for the same cask.
- [x] Checked there aren’t closed [issues](https://github.com/caskroom/homebrew-fonts/issues) where that cask was already refused.
- [x] When naming the cask, followed the [reference](https://github.com/caskroom/homebrew-fonts/blob/master/CONTRIBUTING.md#naming-font-casks).
- [x] Commit message includes cask’s name.
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.

A community driven extension of Google's official "Material Icons" set.

The "brew cask style" command fails because the repo URL and the main site do not match.  I tried to add the comment like it suggests but that even still fails.  It works ok regardless.