### PR TITLE
fixed gravitas-one installation

### DIFF
--- a/Casks/font-gravitas-one.rb
+++ b/Casks/font-gravitas-one.rb
@@ -1,8 +1,14 @@
 cask 'font-gravitas-one' do
-  version '1.001'
-  sha256 'b40dc45f3354f282107286acf1542072d258c717c8edf1d118ef0105f25e627b'
+  # version '3.000'
+  version :latest
+  sha256 :no_check
 
-  url 'https://googlefontdirectory.googlecode.com/hg-history/67342bc472599b4c32201ee4a002fe59a6447a42/ofl/gravitasone/GravitasOne.ttf'
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/trunk/ofl/gravitasone',
+      using:      :svn,
+      revision:   '50',
+      trust_cert: true
+  name 'Gravitas One'
   homepage 'http://www.google.com/fonts/specimen/Gravitas%20One'
   license :ofl
 


### PR DESCRIPTION
The URL was wrong, as well as a few other small
details (e.g., lack of a `name' stanza).

### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.