### PR TITLE
fixed montserrat installation

### DIFF
--- a/Casks/font-montserrat.rb
+++ b/Casks/font-montserrat.rb
@@ -3,10 +3,11 @@ cask 'font-montserrat' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/JulietaUla/Montserrat/trunk/otf',
+  url 'https://github.com/JulietaUla/Montserrat/trunk/fonts/otf',
       using:      :svn,
       revision:   '50',
       trust_cert: true
+  name 'Montserrat'
   homepage 'https://github.com/JulietaUla/Montserrat'
   license :ofl
 


### PR DESCRIPTION
The URL was wrong, as well as the lack of a `name' stanza.

### Changes to a cask
#### Editing an existing cask

- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.