### PR TITLE
Update font-varela

### DIFF
--- a/Casks/font-varela.rb
+++ b/Casks/font-varela.rb
@@ -1,8 +1,13 @@
 cask 'font-varela' do
-  version '1.000'
-  sha256 '87cf0ddd50cd297cd6facfaac8bf59bf8d0b1a3b8b6619957ba08e72043d1896'
+  version :latest
+  sha256 :no_check
 
-  url 'https://googlefontdirectory.googlecode.com/hg-history/67342bc472599b4c32201ee4a002fe59a6447a42/ofl/varela/Varela-Regular.ttf'
+  # github.com/google/fonts/trunk/ofl/varela was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/trunk/ofl/varela',
+      using:      :svn,
+      revision:   '796',
+      trust_cert: true
+  name 'Varela'
   homepage 'http://www.google.com/fonts/specimen/Varela'
   license :ofl
 


### PR DESCRIPTION
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.

Update Varela font due that its previous URL was broken. It points now to google/fonts repo. Other changes have been made in the Cask in order to make it work with the new URL.

- Added `URL_SECTION` because `url` (github) differs from `homepage` (google) but it's a trusted source