### PR TITLE
update font-dejavu-sans and font-ubuntu

### DIFF
--- a/Casks/font-dejavu-sans.rb
+++ b/Casks/font-dejavu-sans.rb
@@ -1,12 +1,14 @@
 cask 'font-dejavu-sans' do
-  version '2.35'
-  sha256 '7e0d00f20080784c3a38a845d5858c161af14f0073d9474cdbfdedae883cc747'
+  version '2.37'
+  sha256 '7576310b219e04159d35ff61dd4a4ec4cdba4f35c00e002a136f00e96a908b0a'
 
-  url "http://downloads.sourceforge.net/sourceforge/dejavu/dejavu-fonts-ttf-#{version}.zip"
+  # sourceforge.net/dejavu was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/dejavu/dejavu-fonts-ttf-#{version}.zip"
   name 'DejaVu'
   homepage 'http://dejavu-fonts.org/wiki/Main_Page'
   license :oss
 
+  font "dejavu-fonts-ttf-#{version}/ttf/DejaVuMathTeXGyre.ttf"
   font "dejavu-fonts-ttf-#{version}/ttf/DejaVuSans-Bold.ttf"
   font "dejavu-fonts-ttf-#{version}/ttf/DejaVuSans-BoldOblique.ttf"
   font "dejavu-fonts-ttf-#{version}/ttf/DejaVuSans-ExtraLight.ttf"

--- a/Casks/font-ubuntu.rb
+++ b/Casks/font-ubuntu.rb
@@ -1,8 +1,9 @@
 cask 'font-ubuntu' do
-  version '0.80'
-  sha256 '107170099bbc3beae8602b97a5c423525d363106c3c24f787d43e09811298e4c'
+  version '0.83'
+  sha256 '456d7d42797febd0d7d4cf1b782a2e03680bb4a5ee43cc9d06bda172bac05b42'
 
   url "http://font.ubuntu.com/download/ubuntu-font-family-#{version}.zip"
+  name 'Ubuntu'
   homepage 'http://font.ubuntu.com/'
   license :ubuntu_font
 


### PR DESCRIPTION
- [x] Commit message includes cask’s name (and new version, if applicable).
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.

```
bash -x -c 'rm -rf ~/Library/Caches/Homebrew/Cask/; brew cask style --fix `git diff master --name-only`; brew cask audit --download `git diff master --name-only`'

+ rm -rf /Users/chulki/Library/Caches/Homebrew/Cask/
++ git diff master --name-only
+ brew cask style --fix Casks/font-dejavu-sans.rb Casks/font-ubuntu.rb

2 files inspected, no offenses detected
++ git diff master --name-only
+ brew cask audit --download Casks/font-dejavu-sans.rb Casks/font-ubuntu.rb
==> Downloading https://downloads.sourceforge.net/dejavu/dejavu-fonts-ttf-2.37.zip
######################################################################## 100.0%
==> Verifying checksum for Cask font-dejavu-sans
audit for font-dejavu-sans: passed
==> Downloading http://font.ubuntu.com/download/ubuntu-font-family-0.83.zip
######################################################################## 100.0%
==> Verifying checksum for Cask font-ubuntu
audit for font-ubuntu: passed
```