### PR TITLE
Add GenJyuuGothic font series

### DIFF
--- a/Casks/font-genjyuugothic-l.rb
+++ b/Casks/font-genjyuugothic-l.rb
@@ -1,0 +1,32 @@
+cask 'font-genjyuugothic-l' do
+  version '20150607,8.643'
+  sha256 'd2fccec290232df110d1116fef4411416875acf7647084c9ab7d7eb5e8a80c50'
+
+  # osdn.jp was verified as official when first introduced to the cask
+  url "http://osdn.dl.osdn.jp/users/#{version.after_comma.major}/#{version.after_comma.no_dots}/genjyuugothic-l-#{version.before_comma}.zip"
+  name 'Gen Jyuu GothicL'
+  homepage 'http://jikasei.me/font/genjyuu/'
+  license :ofl
+
+  font 'GenJyuuGothicL-Bold.ttf'
+  font 'GenJyuuGothicL-ExtraLight.ttf'
+  font 'GenJyuuGothicL-Heavy.ttf'
+  font 'GenJyuuGothicL-Light.ttf'
+  font 'GenJyuuGothicL-Medium.ttf'
+  font 'GenJyuuGothicL-Monospace-Bold.ttf'
+  font 'GenJyuuGothicL-Monospace-ExtraLight.ttf'
+  font 'GenJyuuGothicL-Monospace-Heavy.ttf'
+  font 'GenJyuuGothicL-Monospace-Light.ttf'
+  font 'GenJyuuGothicL-Monospace-Medium.ttf'
+  font 'GenJyuuGothicL-Monospace-Normal.ttf'
+  font 'GenJyuuGothicL-Monospace-Regular.ttf'
+  font 'GenJyuuGothicL-Normal.ttf'
+  font 'GenJyuuGothicL-P-Bold.ttf'
+  font 'GenJyuuGothicL-P-ExtraLight.ttf'
+  font 'GenJyuuGothicL-P-Heavy.ttf'
+  font 'GenJyuuGothicL-P-Light.ttf'
+  font 'GenJyuuGothicL-P-Medium.ttf'
+  font 'GenJyuuGothicL-P-Normal.ttf'
+  font 'GenJyuuGothicL-P-Regular.ttf'
+  font 'GenJyuuGothicL-Regular.ttf'
+end

--- a/Casks/font-genjyuugothic-x.rb
+++ b/Casks/font-genjyuugothic-x.rb
@@ -1,0 +1,32 @@
+cask 'font-genjyuugothic-x' do
+  version '20150607,8.644'
+  sha256 'e4a0ea11b8155056ad2b678c8501b2e76dd99b8c8eb5363d396fe7c3079201b3'
+
+  # osdn.jp was verified as official when first introduced to the cask
+  url "http://osdn.dl.osdn.jp/users/#{version.after_comma.major}/#{version.after_comma.no_dots}/genjyuugothic-x-#{version.before_comma}.zip"
+  name 'Gen Jyuu GothicX'
+  homepage 'http://jikasei.me/font/genjyuu/'
+  license :ofl
+
+  font 'GenJyuuGothicX-Bold.ttf'
+  font 'GenJyuuGothicX-ExtraLight.ttf'
+  font 'GenJyuuGothicX-Heavy.ttf'
+  font 'GenJyuuGothicX-Light.ttf'
+  font 'GenJyuuGothicX-Medium.ttf'
+  font 'GenJyuuGothicX-Monospace-Bold.ttf'
+  font 'GenJyuuGothicX-Monospace-ExtraLight.ttf'
+  font 'GenJyuuGothicX-Monospace-Heavy.ttf'
+  font 'GenJyuuGothicX-Monospace-Light.ttf'
+  font 'GenJyuuGothicX-Monospace-Medium.ttf'
+  font 'GenJyuuGothicX-Monospace-Normal.ttf'
+  font 'GenJyuuGothicX-Monospace-Regular.ttf'
+  font 'GenJyuuGothicX-Normal.ttf'
+  font 'GenJyuuGothicX-P-Bold.ttf'
+  font 'GenJyuuGothicX-P-ExtraLight.ttf'
+  font 'GenJyuuGothicX-P-Heavy.ttf'
+  font 'GenJyuuGothicX-P-Light.ttf'
+  font 'GenJyuuGothicX-P-Medium.ttf'
+  font 'GenJyuuGothicX-P-Normal.ttf'
+  font 'GenJyuuGothicX-P-Regular.ttf'
+  font 'GenJyuuGothicX-Regular.ttf'
+end

--- a/Casks/font-genjyuugothic.rb
+++ b/Casks/font-genjyuugothic.rb
@@ -1,0 +1,32 @@
+cask 'font-genjyuugothic' do
+  version '20150607,8.642'
+  sha256 '916bbc234b110835b9a66ea47fd62e553fd9a524226b1b1fdac6668f0fc95809'
+
+  # osdn.jp was verified as official when first introduced to the cask
+  url "http://osdn.dl.osdn.jp/users/#{version.after_comma.major}/#{version.after_comma.no_dots}/genjyuugothic-#{version.before_comma}.zip"
+  name 'Gen Jyuu Gothic'
+  homepage 'http://jikasei.me/font/genjyuu/'
+  license :ofl
+
+  font 'GenJyuuGothic-Bold.ttf'
+  font 'GenJyuuGothic-ExtraLight.ttf'
+  font 'GenJyuuGothic-Heavy.ttf'
+  font 'GenJyuuGothic-Light.ttf'
+  font 'GenJyuuGothic-Medium.ttf'
+  font 'GenJyuuGothic-Monospace-Bold.ttf'
+  font 'GenJyuuGothic-Monospace-ExtraLight.ttf'
+  font 'GenJyuuGothic-Monospace-Heavy.ttf'
+  font 'GenJyuuGothic-Monospace-Light.ttf'
+  font 'GenJyuuGothic-Monospace-Medium.ttf'
+  font 'GenJyuuGothic-Monospace-Normal.ttf'
+  font 'GenJyuuGothic-Monospace-Regular.ttf'
+  font 'GenJyuuGothic-Normal.ttf'
+  font 'GenJyuuGothic-P-Bold.ttf'
+  font 'GenJyuuGothic-P-ExtraLight.ttf'
+  font 'GenJyuuGothic-P-Heavy.ttf'
+  font 'GenJyuuGothic-P-Light.ttf'
+  font 'GenJyuuGothic-P-Medium.ttf'
+  font 'GenJyuuGothic-P-Normal.ttf'
+  font 'GenJyuuGothic-P-Regular.ttf'
+  font 'GenJyuuGothic-Regular.ttf'
+end


### PR DESCRIPTION
### Adding new casks

Add GenJyuuGothic font serise with three variation:

* GenJyuuGothic (normal type)
* GenJyuuGothic L (with weaker rounded end-caps)
* GenJyuuGothic X (with stronger rounded end-caps)

### Checklist

- [x] The commit message includes the cask’s name and version.
- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] Checked there are no open [pull requests](https://github.com/caskroom/homebrew-fonts/pulls) for the same cask.
- [x] Checked there are no closed [issues](https://github.com/caskroom/homebrew-fonts/issues) where that cask was already refused.
- [x] When naming the cask, followed the [token reference](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md).
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
