### PR TITLE
Fix League Spartan Font

### DIFF
--- a/Casks/font-league-spartan.rb
+++ b/Casks/font-league-spartan.rb
@@ -3,8 +3,9 @@ cask 'font-league-spartan' do
   sha256 'a166294a7e156a0eb14df5714acfeeb3ad4db01eab2bc88f961695da917337fd'
 
   url "http://files.theleagueofmoveabletype.com/downloads/league-spartan-#{version}.zip"
+  name 'League Spartan'
   homepage 'https://www.theleagueofmoveabletype.com/league-spartan'
   license :ofl
 
-  font "league-spartan-#{version}/LeagueSpartan-Bold.otf"
+  font 'league-spartan-master/LeagueSpartan-Bold.otf'
 end


### PR DESCRIPTION
Directory name in [zip file](http://files.theleagueofmoveabletype.com/downloads/league-spartan-c350408b07.zip) is `league-spartan-master` instead of `league-spartan-#{version}`.

Also address #437

### Checklist

- [x] The commit message includes the cask’s name and version. - version unchanged
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.