### PR TITLE
Updated font-charis-sil to version 5.000

### DIFF
--- a/Casks/font-charis-sil.rb
+++ b/Casks/font-charis-sil.rb
@@ -1,9 +1,10 @@
 cask 'font-charis-sil' do
-  version '4.114'
-  sha256 '92ea75512a0bee4d491ba23fb295fd410707f6e8dedacd1af81e222a3081dd56'
+  version '5.000'
+  sha256 '5e3e5473b30363008c289cc87e2aa584a0916087a63a3f689defa8e0cee09bfd'
 
-  url "https://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=CharisSIL-#{version}.zip&filename=CharisSIL-#{version}.zip"
-  homepage 'https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=CharisSILfont'
+  url "http://software.sil.org/downloads/charis/CharisSIL-#{version}.zip"
+  name 'Charis SIL'
+  homepage 'http://software.sil.org/charis/download/'
   license :ofl
 
   font "CharisSIL-#{version}/CharisSIL-R.ttf"


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed

