### PR TITLE
Add font-monofur-for-powerline

### DIFF
--- a/Casks/font-monofur-for-powerline.rb
+++ b/Casks/font-monofur-for-powerline.rb
@@ -1,0 +1,14 @@
+cask 'font-monofur-for-powerline' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://github.com/powerline/fonts/trunk/Monofur',
+      using:      :svn,
+      trust_cert: true
+  name 'monofur for Powerline'
+  homepage 'https://github.com/powerline/fonts/tree/master/Monofur'
+
+  font 'Monofur Bold for Powerline.ttf'
+  font 'Monofur Italic for Powerline.ttf'
+  font 'Monofur for Powerline.ttf'
+end


### PR DESCRIPTION
- [ ] `brew cask audit --download {{cask_file}}` is error-free.

> Audit still check for `license` stanza, output is 
```
$ brew cask audit --download font-monofur-for-powerline.rb
Already downloaded: /Users/orax/Library/Caches/Homebrew/Cask/font-monofur-for-powerline--svn-latest.tar
==> No checksum defined for Cask font-monofur-for-powerline, skipping verificati
audit for font-monofur-for-powerline: failed
 - a license stanza is required (:unknown is OK)
Error: audit failed for casks: font-monofur-for-powerline
```

- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed

