### PR TITLE
Update font-arial-black to 2.35

### DIFF
--- a/Casks/font-arial-black.rb
+++ b/Casks/font-arial-black.rb
@@ -2,7 +2,8 @@ cask 'font-arial-black' do
   version '2.35'
   sha256 'a425f0ffb6a1a5ede5b979ed6177f4f4f4fdef6ae7c302a7b7720ef332fec0a8'
 
-  url 'http://downloads.sourceforge.net/sourceforge/corefonts/arialb32.exe'
+  url 'https://downloads.sourceforge.net/corefonts/arialb32.exe'
+  name 'Arial Black'
   homepage 'http://sourceforge.net/projects/corefonts/files/the%20fonts/final/'
 
   depends_on formula: 'cabextract'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.