### PR TITLE
Update font-arial to 2.82

### DIFF
--- a/Casks/font-arial.rb
+++ b/Casks/font-arial.rb
@@ -2,7 +2,8 @@ cask 'font-arial' do
   version '2.82'
   sha256 '85297a4d146e9c87ac6f74822734bdee5f4b2a722d7eaa584b7f2cbf76f478f6'
 
-  url 'http://downloads.sourceforge.net/sourceforge/corefonts/arial32.exe'
+  url 'https://downloads.sourceforge.net/corefonts/arial32.exe'
+  name 'Arial'
   homepage 'http://sourceforge.net/projects/corefonts/files/the%20fonts/final/'
 
   depends_on formula: 'cabextract'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.