### PR TITLE
Update font-courier-new to 2.82

### DIFF
--- a/Casks/font-courier-new.rb
+++ b/Casks/font-courier-new.rb
@@ -2,7 +2,8 @@ cask 'font-courier-new' do
   version '2.82'
   sha256 'bb511d861655dde879ae552eb86b134d6fae67cb58502e6ff73ec5d9151f3384'
 
-  url 'http://downloads.sourceforge.net/sourceforge/corefonts/courie32.exe'
+  url 'https://downloads.sourceforge.net/corefonts/courie32.exe'
+  name 'Courier New'
   homepage 'http://sourceforge.net/projects/corefonts/files/the%20fonts/final/'
 
   depends_on formula: 'cabextract'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.