### PR TITLE
Update font-d2coding to 1.1,2015.11.03

### DIFF
--- a/Casks/font-d2coding.rb
+++ b/Casks/font-d2coding.rb
@@ -1,8 +1,9 @@
 cask 'font-d2coding' do
-  version '1.1'
+  version '1.1,2015.11.03'
   sha256 '62c8f3766769bfc435dee6f8adadb1e9820515d330bd495f74d0f876909f8daf'
 
-  url 'http://dev.naver.com/frs/download.php/11568/D2Coding-Ver1.1-TTC-20151103.zip'
+  url "http://dev.naver.com/frs/download.php/11568/D2Coding-Ver#{version.before_comma}-TTC-#{version.after_comma.no_dots}.zip"
+  name 'D2 Coding'
   homepage 'http://dev.naver.com/projects/d2coding'
 
   font 'D2Coding.ttc'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.