### PR TITLE
Update font-eb-garamond to 0.016

### DIFF
--- a/Casks/font-eb-garamond.rb
+++ b/Casks/font-eb-garamond.rb
@@ -2,27 +2,31 @@ cask 'font-eb-garamond' do
   version '0.016'
   sha256 'a0b77b405f55c10cff078787ef9d2389a9638e7604d53aa80207fe62e104c378'
 
-  url 'https://bitbucket.org/georgd/eb-garamond/downloads/EBGaramond-0.016.zip'
+  # bitbucket.org/georgd/eb-garamond was verified as official when first introduced to the cask
+  url "https://bitbucket.org/georgd/eb-garamond/downloads/EBGaramond-#{version}.zip"
+  appcast 'https://github.com/georgd/EB-Garamond/releases.atom',
+          checkpoint: '05663636d3d9b6c714c4a377326248ffd7f4f68d3b133ffbb638aeddd3d8f097'
+  name 'EB Garamond'
   homepage 'https://github.com/georgd/EB-Garamond'
 
-  font 'EBGaramond-0.016/otf/EBGaramond-Initials.otf'
-  font 'EBGaramond-0.016/otf/EBGaramond-InitialsF1.otf'
-  font 'EBGaramond-0.016/otf/EBGaramond-InitialsF2.otf'
-  font 'EBGaramond-0.016/otf/EBGaramond08-Italic.otf'
-  font 'EBGaramond-0.016/otf/EBGaramond08-Regular.otf'
-  font 'EBGaramond-0.016/otf/EBGaramond12-AllSC.otf'
-  font 'EBGaramond-0.016/otf/EBGaramond12-Italic.otf'
-  font 'EBGaramond-0.016/otf/EBGaramond12-Regular.otf'
-  font 'EBGaramond-0.016/otf/EBGaramondSC08-Regular.otf'
-  font 'EBGaramond-0.016/otf/EBGaramondSC12-Regular.otf'
-  font 'EBGaramond-0.016/ttf/EBGaramond-Initials.ttf'
-  font 'EBGaramond-0.016/ttf/EBGaramond-InitialsF1.ttf'
-  font 'EBGaramond-0.016/ttf/EBGaramond-InitialsF2.ttf'
-  font 'EBGaramond-0.016/ttf/EBGaramond08-Italic.ttf'
-  font 'EBGaramond-0.016/ttf/EBGaramond08-Regular.ttf'
-  font 'EBGaramond-0.016/ttf/EBGaramond12-AllSC.ttf'
-  font 'EBGaramond-0.016/ttf/EBGaramond12-Italic.ttf'
-  font 'EBGaramond-0.016/ttf/EBGaramond12-Regular.ttf'
-  font 'EBGaramond-0.016/ttf/EBGaramondSC08-Regular.ttf'
-  font 'EBGaramond-0.016/ttf/EBGaramondSC12-Regular.ttf'
+  font "EBGaramond-#{version}/otf/EBGaramond-Initials.otf"
+  font "EBGaramond-#{version}/otf/EBGaramond-InitialsF1.otf"
+  font "EBGaramond-#{version}/otf/EBGaramond-InitialsF2.otf"
+  font "EBGaramond-#{version}/otf/EBGaramond08-Italic.otf"
+  font "EBGaramond-#{version}/otf/EBGaramond08-Regular.otf"
+  font "EBGaramond-#{version}/otf/EBGaramond12-AllSC.otf"
+  font "EBGaramond-#{version}/otf/EBGaramond12-Italic.otf"
+  font "EBGaramond-#{version}/otf/EBGaramond12-Regular.otf"
+  font "EBGaramond-#{version}/otf/EBGaramondSC08-Regular.otf"
+  font "EBGaramond-#{version}/otf/EBGaramondSC12-Regular.otf"
+  font "EBGaramond-#{version}/ttf/EBGaramond-Initials.ttf"
+  font "EBGaramond-#{version}/ttf/EBGaramond-InitialsF1.ttf"
+  font "EBGaramond-#{version}/ttf/EBGaramond-InitialsF2.ttf"
+  font "EBGaramond-#{version}/ttf/EBGaramond08-Italic.ttf"
+  font "EBGaramond-#{version}/ttf/EBGaramond08-Regular.ttf"
+  font "EBGaramond-#{version}/ttf/EBGaramond12-AllSC.ttf"
+  font "EBGaramond-#{version}/ttf/EBGaramond12-Italic.ttf"
+  font "EBGaramond-#{version}/ttf/EBGaramond12-Regular.ttf"
+  font "EBGaramond-#{version}/ttf/EBGaramondSC08-Regular.ttf"
+  font "EBGaramond-#{version}/ttf/EBGaramondSC12-Regular.ttf"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.