### PR TITLE
Update font-fantasque-sans-mono to 1.7.1

### DIFF
--- a/Casks/font-fantasque-sans-mono.rb
+++ b/Casks/font-fantasque-sans-mono.rb
@@ -1,8 +1,11 @@
 cask 'font-fantasque-sans-mono' do
-  version 'v1.7.1'
+  version '1.7.1'
   sha256 '6bb3b24413b78eed19ffa9bd233ae555982e3b185bd303e57dd1e05bebf17352'
 
-  url "https://github.com/belluzj/fantasque-sans/releases/download/#{version}/FantasqueSansMono.zip"
+  url "https://github.com/belluzj/fantasque-sans/releases/download/v#{version}/FantasqueSansMono.zip"
+  appcast 'https://github.com/belluzj/fantasque-sans/releases.atom',
+          checkpoint: '8085c3dff43a9dbf3201ca790c57800a089d1b69fec91226a600c04d9c681e36'
+  name 'Fantasque Sans Mono'
   homepage 'https://github.com/belluzj/fantasque-sans'
 
   font 'OTF/FantasqueSansMono-Bold.otf'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.