### PR TITLE
Update font-georgia to 2.05

### DIFF
--- a/Casks/font-georgia.rb
+++ b/Casks/font-georgia.rb
@@ -2,7 +2,8 @@ cask 'font-georgia' do
   version '2.05'
   sha256 '2c2c7dcda6606ea5cf08918fb7cd3f3359e9e84338dc690013f20cd42e930301'
 
-  url 'http://downloads.sourceforge.net/sourceforge/corefonts/georgi32.exe'
+  url 'https://downloads.sourceforge.net/corefonts/georgi32.exe'
+  name 'Georgia'
   homepage 'http://sourceforge.net/projects/corefonts/files/the%20fonts/final/'
 
   depends_on formula: 'cabextract'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.