### PR TITLE
Update font-hermit to 1.21

### DIFF
--- a/Casks/font-hermit.rb
+++ b/Casks/font-hermit.rb
@@ -3,6 +3,7 @@ cask 'font-hermit' do
   sha256 '2966e83f012e6a31a861e3afdcb89d157f12b307f2367303d58be364d4308b85'
 
   url "https://pcaro.es/d/otf-hermit-#{version}.tar.gz"
+  name 'Hermit'
   homepage 'https://pcaro.es/p/hermit/'
 
   font 'Hermit-bold.otf'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.