### PR TITLE
Update font-hind to 2.000

### DIFF
--- a/Casks/font-hind.rb
+++ b/Casks/font-hind.rb
@@ -2,9 +2,10 @@ cask 'font-hind' do
   version '2.000'
   sha256 '8748ce1fa0db67d0c782d7824a9fdcf0b8544b9d063db477dff9733774571193'
 
-  url 'https://github.com/itfoundry/hind/releases/download/v2.000/hind-2_000.zip'
+  url "https://github.com/itfoundry/hind/releases/download/v2.000/hind-#{version.dots_to_underscores}.zip"
   appcast 'https://github.com/itfoundry/hind/releases.atom',
           checkpoint: '017f74f380a4da8c683f65c195a11e17b6454bd53fe5ab757aa6d3e03b6a0bf4'
+  name 'Hind'
   homepage 'https://github.com/itfoundry/hind'
 
   font 'Hind-Bold.otf'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.