### PR TITLE
Update font-impact to 2.35

### DIFF
--- a/Casks/font-impact.rb
+++ b/Casks/font-impact.rb
@@ -2,7 +2,8 @@ cask 'font-impact' do
   version '2.35'
   sha256 '6061ef3b7401d9642f5dfdb5f2b376aa14663f6275e60a51207ad4facf2fccfb'
 
-  url 'http://downloads.sourceforge.net/sourceforge/corefonts/impact32.exe'
+  url 'https://downloads.sourceforge.net/corefonts/impact32.exe'
+  name 'Impact'
   homepage 'http://sourceforge.net/projects/corefonts/files/the%20fonts/final/'
 
   depends_on formula: 'cabextract'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.