### PR TITLE
Update font-linux-libertine to 5.3.0_2012_07_02

### DIFF
--- a/Casks/font-linux-libertine.rb
+++ b/Casks/font-linux-libertine.rb
@@ -1,8 +1,10 @@
 cask 'font-linux-libertine' do
-  version '5.3.0'
+  version '5.3.0_2012_07_02'
   sha256 '24a593a949808d976850131a953c0c0d7a72299531dfbb348191964cc038d75d'
 
-  url 'http://downloads.sourceforge.net/project/linuxlibertine/linuxlibertine/5.3.0/LinLibertineTTF_5.3.0_2012_07_02.tgz'
+  # downloads.sourceforge.net/linuxlibertine was verified as official when first introduced to the cask
+  url "https://downloads.sourceforge.net/linuxlibertine/LinLibertineTTF_#{version}.tgz"
+  name 'Linux Libertine'
   homepage 'http://linuxlibertine.org'
 
   font 'LinLibertine_DRah.ttf'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.