### PR TITLE
Update font-myrica to 2.006.20150301

### DIFF
--- a/Casks/font-myrica.rb
+++ b/Casks/font-myrica.rb
@@ -1,8 +1,12 @@
 cask 'font-myrica' do
-  version :latest
-  sha256 :no_check
+  version '2.006.20150301'
+  sha256 'ac85d476a7a8cc809be015b9593afff2d998e7cea3b9fd9aee7d9d9a05ba449b'
 
-  url 'https://github.com/tomokuni/Myrica/raw/master/product/Myrica.zip'
+  # codeload.github.com/tomokuni was verified as official when first introduced to the cask
+  url "https://codeload.github.com/tomokuni/Myrica/zip/#{version}"
+  appcast 'https://github.com/tomokuni/Myrica/releases.atom',
+          checkpoint: '6a94ff870981dd8239c762cea15eeb9d1e4df1e0b8c9d22c59c408779b195495'
+  name 'Myrica'
   homepage 'http://myrica.estable.jp/'
 
   font 'Myrica.TTC'

--- a/Casks/font-myrica.rb
+++ b/Casks/font-myrica.rb
@@ -2,7 +2,7 @@ cask 'font-myrica' do
   version '2.006.20150301'
   sha256 'ac85d476a7a8cc809be015b9593afff2d998e7cea3b9fd9aee7d9d9a05ba449b'
 
-  # codeload.github.com/tomokuni was verified as official when first introduced to the cask
+  # codeload.github.com/tomokuni/Myrica was verified as official when first introduced to the cask
   url "https://codeload.github.com/tomokuni/Myrica/zip/#{version}"
   appcast 'https://github.com/tomokuni/Myrica/releases.atom',
           checkpoint: '6a94ff870981dd8239c762cea15eeb9d1e4df1e0b8c9d22c59c408779b195495'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.