### PR TITLE
Update font-namdhinggo-sil to 1.004

### DIFF
--- a/Casks/font-namdhinggo-sil.rb
+++ b/Casks/font-namdhinggo-sil.rb
@@ -3,6 +3,7 @@ cask 'font-namdhinggo-sil' do
   sha256 '8bd69ee93687f2b3fcb705b0c8867c8ff573edcaf9a5c51a08a8ca1c1ddc966b'
 
   url "https://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=NamdhinggoSIL#{version}&filename=NamdhinggoSIL#{version}.zip"
+  name 'Namdhinggo SIL '
   homepage 'https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=NamdhinggoSIL'
 
   font 'NamdhinggoSIL/NamdhinggoSIL-R.ttf'

--- a/Casks/font-namdhinggo-sil.rb
+++ b/Casks/font-namdhinggo-sil.rb
@@ -3,7 +3,7 @@ cask 'font-namdhinggo-sil' do
   sha256 '8bd69ee93687f2b3fcb705b0c8867c8ff573edcaf9a5c51a08a8ca1c1ddc966b'
 
   url "https://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=NamdhinggoSIL#{version}&filename=NamdhinggoSIL#{version}.zip"
-  name 'Namdhinggo SIL '
+  name 'Namdhinggo SIL'
   homepage 'https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=NamdhinggoSIL'
 
   font 'NamdhinggoSIL/NamdhinggoSIL-R.ttf'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.