### PR TITLE
Update font-ocra to 0.9

### DIFF
--- a/Casks/font-ocra.rb
+++ b/Casks/font-ocra.rb
@@ -1,15 +1,17 @@
 cask 'font-ocra' do
-  version '2'
-  sha256 '39289c641520265ecedbade99f01600f316f8196ec57f71c8402d3ba09438666'
+  version '0.9'
+  sha256 '4cdecd9c66582b2f0cf8e02c40fbd260f05c46c802d9bddf9d8dd29daf8a85e3'
 
-  url 'http://dl.sourceforge.jp/tsukurimashou/56948/ocr-0.2.zip'
+  # rwthaachen.dl.osdn.jp/tsukurimashou was verified as official when first introduced to the cask
+  url "http://rwthaachen.dl.osdn.jp/tsukurimashou/61823/tsukurimashou-otf-#{version}.zip"
+  name 'OCRA'
   homepage 'http://ansuz.sooke.bc.ca/page/fonts#ocra'
 
-  font 'ocr-0.2/OCRA.otf'
-  font 'ocr-0.2/OCRB.otf'
-  font 'ocr-0.2/OCRBE.otf'
-  font 'ocr-0.2/OCRBF.otf'
-  font 'ocr-0.2/OCRBL.otf'
-  font 'ocr-0.2/OCRBS.otf'
-  font 'ocr-0.2/OCRBX.otf'
+  font "ocr-#{version}/OCRA.otf"
+  font "ocr-#{version}/OCRB.otf"
+  font "ocr-#{version}/OCRBE.otf"
+  font "ocr-#{version}/OCRBF.otf"
+  font "ocr-#{version}/OCRBL.otf"
+  font "ocr-#{version}/OCRBS.otf"
+  font "ocr-#{version}/OCRBX.otf"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.