### PR TITLE
Update font-office-code-pro to 1.004

### DIFF
--- a/Casks/font-office-code-pro.rb
+++ b/Casks/font-office-code-pro.rb
@@ -2,7 +2,10 @@ cask 'font-office-code-pro' do
   version '1.004'
   sha256 '9e24d15309ead8c523ec3f0444ed9c171bba535e109c43b1dde8abfa9d359150'
 
-  url 'https://github.com/nathco/Office-Code-Pro/archive/1.004.zip'
+  url "https://github.com/nathco/Office-Code-Pro/archive/#{version}.zip"
+  appcast 'https://github.com/nathco/Office-Code-Pro/releases.atom',
+          checkpoint: '07f1f6b80696d887148d5999ecffc7112467e7e3d86511c91a9ebf8e485fe0a2'
+  name 'https://github.com/nathco/Office-Code-Pro/releases.atom'
   homepage 'https://github.com/nathco/Office-Code-Pro'
 
   font 'Office-Code-Pro-1.004/Fonts/Office Code Pro D/OTF/OfficeCodeProD-Bold.otf'

--- a/Casks/font-office-code-pro.rb
+++ b/Casks/font-office-code-pro.rb
@@ -5,7 +5,7 @@ cask 'font-office-code-pro' do
   url "https://github.com/nathco/Office-Code-Pro/archive/#{version}.zip"
   appcast 'https://github.com/nathco/Office-Code-Pro/releases.atom',
           checkpoint: '07f1f6b80696d887148d5999ecffc7112467e7e3d86511c91a9ebf8e485fe0a2'
-  name 'https://github.com/nathco/Office-Code-Pro/releases.atom'
+  name 'Office Code Pro'
   homepage 'https://github.com/nathco/Office-Code-Pro'
 
   font 'Office-Code-Pro-1.004/Fonts/Office Code Pro D/OTF/OfficeCodeProD-Bold.otf'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.