### PR TITLE
Update font-open-iconic to 1.1.1

### DIFF
--- a/Casks/font-open-iconic.rb
+++ b/Casks/font-open-iconic.rb
@@ -1,10 +1,13 @@
 cask 'font-open-iconic' do
-  # version '1.1.0'
-  version :latest
-  sha256 :no_check
+  version '1.1.1'
+  sha256 '8acf49f08ae5a069935b48e6be20349c4e9f43fcfc773ea0aba5b972b5b3743c'
 
-  url 'https://github.com/iconic/open-iconic/archive/1.1.0.zip'
+  # codeload.github.com/iconic/open-iconic was verified as official when first introduced to the cask
+  url "https://codeload.github.com/iconic/open-iconic/zip/#{version}"
+  appcast 'https://github.com/iconic/open-iconic/releases.atom',
+          checkpoint: '2a53b2e0b6f41a3cef48ddfb0b8421f66418f805ba11a9c59d138d477bf03616'
+  name 'Open Iconic'
   homepage 'https://useiconic.com/open/'
 
-  font 'open-iconic-1.1.0/font/fonts/open-iconic.ttf'
+  font "open-iconic-#{version}/font/fonts/open-iconic.ttf"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.