### PR TITLE
Update font-poppins to 2.000

### DIFF
--- a/Casks/font-poppins.rb
+++ b/Casks/font-poppins.rb
@@ -2,9 +2,10 @@ cask 'font-poppins' do
   version '2.000'
   sha256 '86f53a3d50baaadca0d7a1aaf4d69e4d8d3a3d8a9fe67bc3d9b0c0db000e0f39'
 
-  url 'https://github.com/itfoundry/poppins/releases/download/v2.000/poppins-2_000.zip'
+  url "https://github.com/itfoundry/poppins/releases/download/v#{version}/poppins-#{version.dots_to_underscores}.zip"
   appcast 'https://github.com/itfoundry/poppins/releases.atom',
-          checkpoint: '62c4b949034b414f6e3b04d8a1d71a4b360aa266708a3067e64527e288edf549'
+          checkpoint: 'fc011af4ab788e754a052159d7c811132f042811aa8ad8773cebaa7b8d60e3d7'
+  name 'Poppins'
   homepage 'https://github.com/itfoundry/poppins'
 
   font 'Poppins-Bold.otf'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.