### PR TITLE
Update font-rotinonhsonni-sans to 8.7.2001

### DIFF
--- a/Casks/font-rotinonhsonni-sans.rb
+++ b/Casks/font-rotinonhsonni-sans.rb
@@ -1,12 +1,13 @@
 cask 'font-rotinonhsonni-sans' do
-  version '8.722'
+  version '8.7.2001'
   sha256 'c1edbe62bca1e33b6835073610b2a39e1bc41b41eeb438aa918941cd12d3785c'
 
   url 'http://www.languagegeek.com/font/RotinonhSans.zip'
+  name 'Rotinohnsonni Sans'
   homepage 'http://www.languagegeek.com/font/fontdownload.html'
 
-  font 'rotinonhsans8_7_2_2001.ttf'
-  font 'rotinonhsansbi8_7_2_2001.ttf'
-  font 'rotinonsanshb8_7_2_2001.ttf'
-  font 'rotinonsanshi8_7_2_2001.ttf'
+  font "rotinonhsans#{version.dots_to_underscores}.ttf"
+  font "rotinonhsansbi#{version.dots_to_underscores}.ttf"
+  font "rotinonsanshb#{version.dots_to_underscores}.ttf"
+  font "rotinonsanshi#{version.dots_to_underscores}.ttf"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.