### PR TITLE
Fix Octicons archive location

### DIFF
--- a/Casks/font-octicons.rb
+++ b/Casks/font-octicons.rb
@@ -1,6 +1,6 @@
 cask 'font-octicons' do
   version '4.4.0'
-  sha256 :no_check
+  sha256 '1d3b27b1096c57edb4d391a6b1ec1e672e64b250bec4c86662f11baba988db3a'
 
   url "https://github.com/primer/octicons/archive/v#{version}.zip"
   appcast 'https://github.com/primer/octicons/releases.atom',

--- a/Casks/font-octicons.rb
+++ b/Casks/font-octicons.rb
@@ -1,8 +1,10 @@
 cask 'font-octicons' do
-  version "4.4.0"
+  version '4.4.0'
   sha256 :no_check
 
   url "https://github.com/primer/octicons/archive/v#{version}.zip"
+  appcast 'https://github.com/primer/octicons/releases.atom',
+          checkpoint: 'af35fc21e4adb5ed1798748d12db7a1ba1d68f486bbbe30841af3d1319b7fbfb'
   name 'Octicons'
   homepage 'https://octicons.github.com'
 

--- a/Casks/font-octicons.rb
+++ b/Casks/font-octicons.rb
@@ -1,10 +1,10 @@
 cask 'font-octicons' do
-  version :latest
+  version "4.4.0"
   sha256 :no_check
 
-  url 'https://github.com/github/octicons/archive/master.zip'
+  url "https://github.com/primer/octicons/archive/v#{version}.zip"
   name 'Octicons'
   homepage 'https://octicons.github.com'
 
-  font 'octicons-master/build/font/octicons.ttf'
+  font "octicons-#{version}/build/font/octicons.ttf"
 end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed

The github/octicons repository moved to primer/octicons. The TTF file is no longer contained in the source repository, so download the latest release zip archive instead.