### PR TITLE
Update font-scheherazade to 2.020

### DIFF
--- a/Casks/font-scheherazade.rb
+++ b/Casks/font-scheherazade.rb
@@ -2,8 +2,9 @@ cask 'font-scheherazade' do
   version '2.020'
   sha256 'd8bb12997507937347efba4e59550a9655350563d1df662f0651e04ba916aff1'
 
-  url 'http://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=Scheherazade-2.020.zip&filename=Scheherazade-2.020.zip'
+  url "http://scripts.sil.org/cms/scripts/render_download.php?format=file&media_id=Scheherazade-#{version}.zip&filename=Scheherazade-#{version}.zip"
+  name 'Scheherazade '
   homepage 'http://scripts.sil.org/Scheherazade'
 
-  font 'Scheherazade-2.020/Scheherazade-R.ttf'
+  font "Scheherazade-#{version}/Scheherazade-R.ttf"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.