### PR TITLE
Update font-xits to 1.108

### DIFF
--- a/Casks/font-xits.rb
+++ b/Casks/font-xits.rb
@@ -3,6 +3,9 @@ cask 'font-xits' do
   sha256 'af5e3eee5c81578810a7f2ffbf4c985d25e879e0128ea1dd6c1389a06eb36347'
 
   url "https://github.com/khaledhosny/xits-math/archive/v#{version}.zip"
+  appcast 'https://github.com/khaledhosny/xits-math/releases.atom',
+          checkpoint: 'b95fbba398884408c293eba5cb6e1e556f0c337db397dd39f20d700634c0e287'
+  name 'XITS'
   homepage 'https://github.com/khaledhosny/xits-math'
 
   font "xits-math-#{version}/xits-bold.otf"


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.