### PR TITLE
Update font-gandom to 0.4.4

### DIFF
--- a/Casks/font-gandom.rb
+++ b/Casks/font-gandom.rb
@@ -1,11 +1,11 @@
 cask 'font-gandom' do
-  version '0.3'
-  sha256 '6a0084ffe9a57744e4c17f9a80c6417e42c3ff28c01bfbec8d399ea2683c4a4b'
+  version '0.4.4'
+  sha256 'ae2ed95be9915b44c10f8a7d33763cecf29683464ecee4b60fcfcf1516ad3a8f'
 
   # github.com/rastikerdar was verified as official when first introduced to the cask
   url "https://github.com/rastikerdar/gandom-font/releases/download/v#{version}/gandom-font-v#{version}.zip"
   appcast 'https://github.com/rastikerdar/gandom-font/releases.atom',
-          checkpoint: '644c9b56d1a64cc7c0569740b8f209cc59d06a3dc21e2e5bba84e9cf79660bab'
+          checkpoint: '1c534d1ac2cb060a5b2ac93839fcb411f84fefb65cf0555d805060270280c0ba'
   name 'Gandom'
   homepage 'http://rastikerdar.github.io/gandom-font'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.