### PR TITLE
Update font-monoisome to 0.61

### DIFF
--- a/Casks/font-monoisome.rb
+++ b/Casks/font-monoisome.rb
@@ -5,7 +5,7 @@ cask 'font-monoisome' do
   # github.com/larsenwork/monoid was verified as official when first introduced to the cask
   url 'https://github.com/larsenwork/monoid/blob/master/Monoisome/Monoisome-Regular.ttf?raw=true'
   appcast 'https://github.com/larsenwork/monoid/releases.atom',
-          checkpoint: 'e94cd1ccc01488e99b07a372162ea9e555b6aef0e0911cbb198281f03b975467'
+          checkpoint: '7d81b051c97512e3973332b07fe3f2013384be867d46c85879117bacebaba111'
   name 'Monoisome'
   homepage 'http://larsenwork.com/monoid/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.