### PR TITLE
Add a cask for the the IBM 3270 font

### DIFF
--- a/Casks/font-3270.rb
+++ b/Casks/font-3270.rb
@@ -1,0 +1,15 @@
+cask 'font-3270' do
+  version '1.2.18'
+  sha256 'cab1323b1da858460c3dc77c03b0446147635d5fce93d575f4d098265e3cf664'
+
+  url 'https://github.com/rbanffy/3270font/releases/download/v1.2.18/3270_fonts_408b9bd.zip'
+  name 'IBM 3270'
+  homepage 'https://github.com/rbanffy/3270font'
+
+  font '3270Medium.otf'
+  font '3270Medium.ttf'
+  font '3270Narrow.otf'
+  font '3270Narrow.ttf'
+  font '3270SemiNarrow.otf'
+  font '3270SemiNarrow.ttf'
+end


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed

The 3270 terminal series was very popular with IBM mainframe users. In
particular, the 3278 and 3279, whose font is reproduced here, were
considered by many as the best terminals ever made.

This font builds up on work that started in the 80's, for the bitmap
font used in the x3270 emulators.