### PR TITLE
Add font-bukyvede-bold

### DIFF
--- a/Casks/font-bukyvede-bold.rb
+++ b/Casks/font-bukyvede-bold.rb
@@ -1,0 +1,10 @@
+cask 'font-bukyvede-bold' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://kodeks.uni-bamberg.de/aksl/media/BukyVede-Bold.ttf'
+  name 'BukyVede Bold'
+  homepage 'http://kodeks.uni-bamberg.de/aksl/Schrift/BukyVede.htm'
+
+  font 'BukyVede-Bold.ttf'
+end


### PR DESCRIPTION
This PR is related to #568 and is the second of three PRs to fix that issue. I've splitted them into three due that there's a different file for each font weight.

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed