### PR TITLE
Add missing fonts from Google fonts

### DIFF
--- a/Casks/font-actor.rb
+++ b/Casks/font-actor.rb
@@ -1,0 +1,11 @@
+cask 'font-actor' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/actor/Actor-Regular.ttf'
+  name 'Actor'
+  homepage 'http://www.google.com/fonts/specimen/Actor'
+
+  font 'Actor-Regular.ttf'
+end

--- a/Casks/font-adamina.rb
+++ b/Casks/font-adamina.rb
@@ -1,0 +1,11 @@
+cask 'font-adamina' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/adamina/Adamina-Regular.ttf'
+  name 'Adamina'
+  homepage 'http://www.google.com/fonts/specimen/Adamina'
+
+  font 'Adamina-Regular.ttf'
+end

--- a/Casks/font-aguafina-script.rb
+++ b/Casks/font-aguafina-script.rb
@@ -1,0 +1,11 @@
+cask 'font-aguafina-script' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/aguafinascript/AguafinaScript-Regular.ttf'
+  name 'Aguafina Script'
+  homepage 'http://www.google.com/fonts/specimen/Aguafina+Script'
+
+  font 'AguafinaScript-Regular.ttf'
+end

--- a/Casks/font-akronim.rb
+++ b/Casks/font-akronim.rb
@@ -1,0 +1,11 @@
+cask 'font-akronim' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/akronim/Akronim-Regular.ttf'
+  name 'Akronim'
+  homepage 'http://www.google.com/fonts/specimen/Akronim'
+
+  font 'Akronim-Regular.ttf'
+end

--- a/Casks/font-aladin.rb
+++ b/Casks/font-aladin.rb
@@ -1,0 +1,11 @@
+cask 'font-aladin' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/aladin/Aladin-Regular.ttf'
+  name 'Aladin'
+  homepage 'http://www.google.com/fonts/specimen/Aladin'
+
+  font 'Aladin-Regular.ttf'
+end

--- a/Casks/font-aldrich.rb
+++ b/Casks/font-aldrich.rb
@@ -1,0 +1,11 @@
+cask 'font-aldrich' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/aldrich/Aldrich-Regular.ttf'
+  name 'Aldrich'
+  homepage 'http://www.google.com/fonts/specimen/Aldrich'
+
+  font 'Aldrich-Regular.ttf'
+end

--- a/Casks/font-alex-brush.rb
+++ b/Casks/font-alex-brush.rb
@@ -1,0 +1,11 @@
+cask 'font-alex-brush' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/alexbrush/AlexBrush-Regular.ttf'
+  name 'Alex Brush'
+  homepage 'http://www.google.com/fonts/specimen/Alex+Brush'
+
+  font 'AlexBrush-Regular.ttf'
+end

--- a/Casks/font-alfa-slab-one.rb
+++ b/Casks/font-alfa-slab-one.rb
@@ -1,0 +1,11 @@
+cask 'font-alfa-slab-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/alfaslabone/AlfaSlabOne-Regular.ttf'
+  name 'Alfa Slab One'
+  homepage 'http://www.google.com/fonts/specimen/Alfa+Slab+One'
+
+  font 'AlfaSlabOne-Regular.ttf'
+end

--- a/Casks/font-alice.rb
+++ b/Casks/font-alice.rb
@@ -1,0 +1,11 @@
+cask 'font-alice' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/alice/Alice-Regular.ttf'
+  name 'Alice'
+  homepage 'http://www.google.com/fonts/specimen/Alice'
+
+  font 'Alice-Regular.ttf'
+end

--- a/Casks/font-alike-angular.rb
+++ b/Casks/font-alike-angular.rb
@@ -1,0 +1,11 @@
+cask 'font-alike-angular' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/alikeangular/AlikeAngular-Regular.ttf'
+  name 'Alike Angular'
+  homepage 'http://www.google.com/fonts/specimen/Alike+Angular'
+
+  font 'AlikeAngular-Regular.ttf'
+end

--- a/Casks/font-alike.rb
+++ b/Casks/font-alike.rb
@@ -1,0 +1,11 @@
+cask 'font-alike' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/alike/Alike-Regular.ttf'
+  name 'Alike'
+  homepage 'http://www.google.com/fonts/specimen/Alike'
+
+  font 'Alike-Regular.ttf'
+end

--- a/Casks/font-allerta-stencil.rb
+++ b/Casks/font-allerta-stencil.rb
@@ -1,0 +1,11 @@
+cask 'font-allerta-stencil' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/allertastencil/AllertaStencil-Regular.ttf'
+  name 'Allerta Stencil'
+  homepage 'http://www.google.com/fonts/specimen/Allerta+Stencil'
+
+  font 'AllertaStencil-Regular.ttf'
+end

--- a/Casks/font-allerta.rb
+++ b/Casks/font-allerta.rb
@@ -1,0 +1,11 @@
+cask 'font-allerta' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/allerta/Allerta-Regular.ttf'
+  name 'Allerta'
+  homepage 'http://www.google.com/fonts/specimen/Allerta'
+
+  font 'Allerta-Regular.ttf'
+end

--- a/Casks/font-almendra-display.rb
+++ b/Casks/font-almendra-display.rb
@@ -1,0 +1,11 @@
+cask 'font-almendra-display' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/almendradisplay/AlmendraDisplay-Regular.ttf'
+  name 'Almendra Display'
+  homepage 'http://www.google.com/fonts/specimen/Almendra+Display'
+
+  font 'AlmendraDisplay-Regular.ttf'
+end

--- a/Casks/font-amarante.rb
+++ b/Casks/font-amarante.rb
@@ -1,0 +1,11 @@
+cask 'font-amarante' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/amarante/Amarante-Regular.ttf'
+  name 'Amarante'
+  homepage 'http://www.google.com/fonts/specimen/Amarante'
+
+  font 'Amarante-Regular.ttf'
+end

--- a/Casks/font-amethysta.rb
+++ b/Casks/font-amethysta.rb
@@ -1,0 +1,11 @@
+cask 'font-amethysta' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/amethysta/Amethysta-Regular.ttf'
+  name 'Amethysta'
+  homepage 'http://www.google.com/fonts/specimen/Amethysta'
+
+  font 'Amethysta-Regular.ttf'
+end

--- a/Casks/font-anaheim.rb
+++ b/Casks/font-anaheim.rb
@@ -1,0 +1,11 @@
+cask 'font-anaheim' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/anaheim/Anaheim-Regular.ttf'
+  name 'Anaheim'
+  homepage 'http://www.google.com/fonts/specimen/Anaheim'
+
+  font 'Anaheim-Regular.ttf'
+end

--- a/Casks/font-angkor.rb
+++ b/Casks/font-angkor.rb
@@ -1,0 +1,11 @@
+cask 'font-angkor' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/angkor/Angkor.ttf'
+  name 'Angkor'
+  homepage 'http://www.google.com/fonts/specimen/Angkor'
+
+  font 'Angkor.ttf'
+end

--- a/Casks/font-annie-use-your-telescope.rb
+++ b/Casks/font-annie-use-your-telescope.rb
@@ -1,0 +1,11 @@
+cask 'font-annie-use-your-telescope' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/annieuseyourtelescope/AnnieUseYourTelescope.ttf'
+  name 'Annie Use Your Telescope'
+  homepage 'http://www.google.com/fonts/specimen/Annie+Use+Your+Telescope'
+
+  font 'AnnieUseYourTelescope.ttf'
+end

--- a/Casks/font-antic-didone.rb
+++ b/Casks/font-antic-didone.rb
@@ -1,0 +1,11 @@
+cask 'font-antic-didone' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/anticdidone/AnticDidone-Regular.ttf'
+  name 'Antic Didone'
+  homepage 'http://www.google.com/fonts/specimen/Antic+Didone'
+
+  font 'AnticDidone-Regular.ttf'
+end

--- a/Casks/font-antic-slab.rb
+++ b/Casks/font-antic-slab.rb
@@ -1,0 +1,11 @@
+cask 'font-antic-slab' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/anticslab/AnticSlab-Regular.ttf'
+  name 'Antic Slab'
+  homepage 'http://www.google.com/fonts/specimen/Antic+Slab'
+
+  font 'AnticSlab-Regular.ttf'
+end

--- a/Casks/font-antic.rb
+++ b/Casks/font-antic.rb
@@ -1,0 +1,11 @@
+cask 'font-antic' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/antic/Antic-Regular.ttf'
+  name 'Antic'
+  homepage 'http://www.google.com/fonts/specimen/Antic'
+
+  font 'Antic-Regular.ttf'
+end

--- a/Casks/font-anton.rb
+++ b/Casks/font-anton.rb
@@ -1,0 +1,11 @@
+cask 'font-anton' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/anton/Anton.ttf'
+  name 'Anton'
+  homepage 'http://www.google.com/fonts/specimen/Anton'
+
+  font 'Anton.ttf'
+end

--- a/Casks/font-arbutus-slab.rb
+++ b/Casks/font-arbutus-slab.rb
@@ -1,0 +1,11 @@
+cask 'font-arbutus-slab' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/arbutusslab/ArbutusSlab-Regular.ttf'
+  name 'Arbutus Slab'
+  homepage 'http://www.google.com/fonts/specimen/Arbutus+Slab'
+
+  font 'ArbutusSlab-Regular.ttf'
+end

--- a/Casks/font-arbutus.rb
+++ b/Casks/font-arbutus.rb
@@ -1,0 +1,11 @@
+cask 'font-arbutus' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/arbutus/Arbutus-Regular.ttf'
+  name 'Arbutus'
+  homepage 'http://www.google.com/fonts/specimen/Arbutus'
+
+  font 'Arbutus-Regular.ttf'
+end

--- a/Casks/font-architects-daughter.rb
+++ b/Casks/font-architects-daughter.rb
@@ -1,0 +1,11 @@
+cask 'font-architects-daughter' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/architectsdaughter/ArchitectsDaughter.ttf'
+  name 'Architects Daughter'
+  homepage 'http://www.google.com/fonts/specimen/Architects+Daughter'
+
+  font 'ArchitectsDaughter.ttf'
+end

--- a/Casks/font-archivo-black.rb
+++ b/Casks/font-archivo-black.rb
@@ -1,0 +1,11 @@
+cask 'font-archivo-black' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/archivoblack/ArchivoBlack-Regular.ttf'
+  name 'Archivo Black'
+  homepage 'http://www.google.com/fonts/specimen/Archivo+Black'
+
+  font 'ArchivoBlack-Regular.ttf'
+end

--- a/Casks/font-arizonia.rb
+++ b/Casks/font-arizonia.rb
@@ -1,0 +1,11 @@
+cask 'font-arizonia' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/arizonia/Arizonia-Regular.ttf'
+  name 'Arizonia'
+  homepage 'http://www.google.com/fonts/specimen/Arizonia'
+
+  font 'Arizonia-Regular.ttf'
+end

--- a/Casks/font-armata.rb
+++ b/Casks/font-armata.rb
@@ -1,0 +1,11 @@
+cask 'font-armata' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/armata/Armata-Regular.ttf'
+  name 'Armata'
+  homepage 'http://www.google.com/fonts/specimen/Armata'
+
+  font 'Armata-Regular.ttf'
+end

--- a/Casks/font-artifika.rb
+++ b/Casks/font-artifika.rb
@@ -1,0 +1,11 @@
+cask 'font-artifika' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/artifika/Artifika-Regular.ttf'
+  name 'Artifika'
+  homepage 'http://www.google.com/fonts/specimen/Artifika'
+
+  font 'Artifika-Regular.ttf'
+end

--- a/Casks/font-asset.rb
+++ b/Casks/font-asset.rb
@@ -1,0 +1,11 @@
+cask 'font-asset' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/asset/Asset.ttf'
+  name 'Asset'
+  homepage 'http://www.google.com/fonts/specimen/Asset'
+
+  font 'Asset.ttf'
+end

--- a/Casks/font-atomic-age.rb
+++ b/Casks/font-atomic-age.rb
@@ -1,0 +1,11 @@
+cask 'font-atomic-age' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/atomicage/AtomicAge-Regular.ttf'
+  name 'Atomic Age'
+  homepage 'http://www.google.com/fonts/specimen/Atomic+Age'
+
+  font 'AtomicAge-Regular.ttf'
+end

--- a/Casks/font-aubrey.rb
+++ b/Casks/font-aubrey.rb
@@ -1,0 +1,11 @@
+cask 'font-aubrey' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/aubrey/Aubrey-Regular.ttf'
+  name 'Aubrey'
+  homepage 'http://www.google.com/fonts/specimen/Aubrey'
+
+  font 'Aubrey-Regular.ttf'
+end

--- a/Casks/font-audiowide.rb
+++ b/Casks/font-audiowide.rb
@@ -1,0 +1,11 @@
+cask 'font-audiowide' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/audiowide/Audiowide-Regular.ttf'
+  name 'Audiowide'
+  homepage 'http://www.google.com/fonts/specimen/Audiowide'
+
+  font 'Audiowide-Regular.ttf'
+end

--- a/Casks/font-autour-one.rb
+++ b/Casks/font-autour-one.rb
@@ -1,0 +1,11 @@
+cask 'font-autour-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/autourone/AutourOne-Regular.ttf'
+  name 'Autour One'
+  homepage 'http://www.google.com/fonts/specimen/Autour+One'
+
+  font 'AutourOne-Regular.ttf'
+end

--- a/Casks/font-averia-gruesa-libre.rb
+++ b/Casks/font-averia-gruesa-libre.rb
@@ -1,0 +1,11 @@
+cask 'font-averia-gruesa-libre' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/averiagruesalibre/AveriaGruesaLibre-Regular.ttf'
+  name 'Averia Gruesa Libre'
+  homepage 'http://www.google.com/fonts/specimen/Averia+Gruesa+Libre'
+
+  font 'AveriaGruesaLibre-Regular.ttf'
+end

--- a/Casks/font-bad-script.rb
+++ b/Casks/font-bad-script.rb
@@ -1,0 +1,11 @@
+cask 'font-bad-script' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/badscript/BadScript-Regular.ttf'
+  name 'Bad Script'
+  homepage 'http://www.google.com/fonts/specimen/Bad+Script'
+
+  font 'BadScript-Regular.ttf'
+end

--- a/Casks/font-balthazar.rb
+++ b/Casks/font-balthazar.rb
@@ -1,0 +1,11 @@
+cask 'font-balthazar' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/balthazar/Balthazar-Regular.ttf'
+  name 'Balthazar'
+  homepage 'http://www.google.com/fonts/specimen/Balthazar'
+
+  font 'Balthazar-Regular.ttf'
+end

--- a/Casks/font-bangers.rb
+++ b/Casks/font-bangers.rb
@@ -1,0 +1,11 @@
+cask 'font-bangers' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bangers/Bangers.ttf'
+  name 'Bangers'
+  homepage 'http://www.google.com/fonts/specimen/Bangers'
+
+  font 'Bangers.ttf'
+end

--- a/Casks/font-basic.rb
+++ b/Casks/font-basic.rb
@@ -1,0 +1,11 @@
+cask 'font-basic' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/basic/Basic-Regular.ttf'
+  name 'Basic'
+  homepage 'http://www.google.com/fonts/specimen/Basic'
+
+  font 'Basic-Regular.ttf'
+end

--- a/Casks/font-baumans.rb
+++ b/Casks/font-baumans.rb
@@ -1,0 +1,11 @@
+cask 'font-baumans' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/baumans/Baumans-Regular.ttf'
+  name 'Baumans'
+  homepage 'http://www.google.com/fonts/specimen/Baumans'
+
+  font 'Baumans-Regular.ttf'
+end

--- a/Casks/font-bayon.rb
+++ b/Casks/font-bayon.rb
@@ -1,0 +1,11 @@
+cask 'font-bayon' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bayon/Bayon.ttf'
+  name 'Bayon'
+  homepage 'http://www.google.com/fonts/specimen/Bayon'
+
+  font 'Bayon.ttf'
+end

--- a/Casks/font-belgrano.rb
+++ b/Casks/font-belgrano.rb
@@ -1,0 +1,11 @@
+cask 'font-belgrano' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/belgrano/Belgrano-Regular.ttf'
+  name 'Belgrano'
+  homepage 'http://www.google.com/fonts/specimen/Belgrano'
+
+  font 'Belgrano-Regular.ttf'
+end

--- a/Casks/font-belleza.rb
+++ b/Casks/font-belleza.rb
@@ -1,0 +1,11 @@
+cask 'font-belleza' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/belleza/Belleza-Regular.ttf'
+  name 'Belleza'
+  homepage 'http://www.google.com/fonts/specimen/Belleza'
+
+  font 'Belleza-Regular.ttf'
+end

--- a/Casks/font-bentham.rb
+++ b/Casks/font-bentham.rb
@@ -1,0 +1,11 @@
+cask 'font-bentham' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bentham/Bentham-Regular.ttf'
+  name 'Bentham'
+  homepage 'http://www.google.com/fonts/specimen/Bentham'
+
+  font 'Bentham-Regular.ttf'
+end

--- a/Casks/font-berkshire-swash.rb
+++ b/Casks/font-berkshire-swash.rb
@@ -1,0 +1,11 @@
+cask 'font-berkshire-swash' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/berkshireswash/BerkshireSwash-Regular.ttf'
+  name 'Berkshire Swash'
+  homepage 'http://www.google.com/fonts/specimen/Berkshire+Swash'
+
+  font 'BerkshireSwash-Regular.ttf'
+end

--- a/Casks/font-bevan.rb
+++ b/Casks/font-bevan.rb
@@ -1,0 +1,11 @@
+cask 'font-bevan' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bevan/Bevan.ttf'
+  name 'Bevan'
+  homepage 'http://www.google.com/fonts/specimen/Bevan'
+
+  font 'Bevan.ttf'
+end

--- a/Casks/font-bigelow-rules.rb
+++ b/Casks/font-bigelow-rules.rb
@@ -1,0 +1,11 @@
+cask 'font-bigelow-rules' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bigelowrules/BigelowRules-Regular.ttf'
+  name 'Bigelow Rules'
+  homepage 'http://www.google.com/fonts/specimen/Bigelow+Rules'
+
+  font 'BigelowRules-Regular.ttf'
+end

--- a/Casks/font-bigshot-one.rb
+++ b/Casks/font-bigshot-one.rb
@@ -1,0 +1,11 @@
+cask 'font-bigshot-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bigshotone/BigshotOne.ttf'
+  name 'Bigshot One'
+  homepage 'http://www.google.com/fonts/specimen/Bigshot+One'
+
+  font 'BigshotOne.ttf'
+end

--- a/Casks/font-bilbo-swash-caps.rb
+++ b/Casks/font-bilbo-swash-caps.rb
@@ -1,0 +1,11 @@
+cask 'font-bilbo-swash-caps' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bilboswashcaps/BilboSwashCaps-Regular.ttf'
+  name 'Bilbo Swash Caps'
+  homepage 'http://www.google.com/fonts/specimen/Bilbo+Swash+Caps'
+
+  font 'BilboSwashCaps-Regular.ttf'
+end

--- a/Casks/font-bilbo.rb
+++ b/Casks/font-bilbo.rb
@@ -1,0 +1,11 @@
+cask 'font-bilbo' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bilbo/Bilbo-Regular.ttf'
+  name 'Bilbo'
+  homepage 'http://www.google.com/fonts/specimen/Bilbo'
+
+  font 'Bilbo-Regular.ttf'
+end

--- a/Casks/font-black-ops-one.rb
+++ b/Casks/font-black-ops-one.rb
@@ -1,0 +1,11 @@
+cask 'font-black-ops-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/blackopsone/BlackOpsOne-Regular.ttf'
+  name 'Black Ops One'
+  homepage 'http://www.google.com/fonts/specimen/Black+Ops+One'
+
+  font 'BlackOpsOne-Regular.ttf'
+end

--- a/Casks/font-bokor.rb
+++ b/Casks/font-bokor.rb
@@ -1,0 +1,11 @@
+cask 'font-bokor' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bokor/Bokor.ttf'
+  name 'Bokor'
+  homepage 'http://www.google.com/fonts/specimen/Bokor'
+
+  font 'Bokor.ttf'
+end

--- a/Casks/font-bonbon.rb
+++ b/Casks/font-bonbon.rb
@@ -1,0 +1,11 @@
+cask 'font-bonbon' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bonbon/Bonbon-Regular.ttf'
+  name 'Bonbon'
+  homepage 'http://www.google.com/fonts/specimen/Bonbon'
+
+  font 'Bonbon-Regular.ttf'
+end

--- a/Casks/font-boogaloo.rb
+++ b/Casks/font-boogaloo.rb
@@ -1,0 +1,11 @@
+cask 'font-boogaloo' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/boogaloo/Boogaloo-Regular.ttf'
+  name 'Boogaloo'
+  homepage 'http://www.google.com/fonts/specimen/Boogaloo'
+
+  font 'Boogaloo-Regular.ttf'
+end

--- a/Casks/font-bowlby-one-sc.rb
+++ b/Casks/font-bowlby-one-sc.rb
@@ -1,0 +1,11 @@
+cask 'font-bowlby-one-sc' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bowlbyonesc/BowlbyOneSC-Regular.ttf'
+  name 'Bowlby One SC'
+  homepage 'http://www.google.com/fonts/specimen/Bowlby+One+SC'
+
+  font 'BowlbyOneSC-Regular.ttf'
+end

--- a/Casks/font-bowlby-one.rb
+++ b/Casks/font-bowlby-one.rb
@@ -1,0 +1,11 @@
+cask 'font-bowlby-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bowlbyone/BowlbyOne-Regular.ttf'
+  name 'Bowlby One'
+  homepage 'http://www.google.com/fonts/specimen/Bowlby+One'
+
+  font 'BowlbyOne-Regular.ttf'
+end

--- a/Casks/font-brawler.rb
+++ b/Casks/font-brawler.rb
@@ -1,0 +1,11 @@
+cask 'font-brawler' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/brawler/Brawler-Regular.ttf'
+  name 'Brawler'
+  homepage 'http://www.google.com/fonts/specimen/Brawler'
+
+  font 'Brawler-Regular.ttf'
+end

--- a/Casks/font-bree-serif.rb
+++ b/Casks/font-bree-serif.rb
@@ -1,0 +1,11 @@
+cask 'font-bree-serif' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/breeserif/BreeSerif-Regular.ttf'
+  name 'Bree Serif'
+  homepage 'http://www.google.com/fonts/specimen/Bree+Serif'
+
+  font 'BreeSerif-Regular.ttf'
+end

--- a/Casks/font-bubblegum-sans.rb
+++ b/Casks/font-bubblegum-sans.rb
@@ -1,0 +1,11 @@
+cask 'font-bubblegum-sans' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bubblegumsans/BubblegumSans-Regular.ttf'
+  name 'Bubblegum Sans'
+  homepage 'http://www.google.com/fonts/specimen/Bubblegum+Sans'
+
+  font 'BubblegumSans-Regular.ttf'
+end

--- a/Casks/font-bubbler-one.rb
+++ b/Casks/font-bubbler-one.rb
@@ -1,0 +1,11 @@
+cask 'font-bubbler-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/bubblerone/BubblerOne-Regular.ttf'
+  name 'Bubbler One'
+  homepage 'http://www.google.com/fonts/specimen/Bubbler+One'
+
+  font 'BubblerOne-Regular.ttf'
+end

--- a/Casks/font-butcherman.rb
+++ b/Casks/font-butcherman.rb
@@ -1,0 +1,11 @@
+cask 'font-butcherman' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/butcherman/Butcherman-Regular.ttf'
+  name 'Butcherman'
+  homepage 'http://www.google.com/fonts/specimen/Butcherman'
+
+  font 'Butcherman-Regular.ttf'
+end

--- a/Casks/font-butterfly-kids.rb
+++ b/Casks/font-butterfly-kids.rb
@@ -1,0 +1,11 @@
+cask 'font-butterfly-kids' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/butterflykids/ButterflyKids-Regular.ttf'
+  name 'Butterfly Kids'
+  homepage 'http://www.google.com/fonts/specimen/Butterfly+Kids'
+
+  font 'ButterflyKids-Regular.ttf'
+end

--- a/Casks/font-caesar-dressing.rb
+++ b/Casks/font-caesar-dressing.rb
@@ -1,0 +1,11 @@
+cask 'font-caesar-dressing' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/caesardressing/CaesarDressing-Regular.ttf'
+  name 'Caesar Dressing'
+  homepage 'http://www.google.com/fonts/specimen/Caesar+Dressing'
+
+  font 'CaesarDressing-Regular.ttf'
+end

--- a/Casks/font-cagliostro.rb
+++ b/Casks/font-cagliostro.rb
@@ -1,0 +1,11 @@
+cask 'font-cagliostro' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/cagliostro/Cagliostro-Regular.ttf'
+  name 'Cagliostro'
+  homepage 'http://www.google.com/fonts/specimen/Cagliostro'
+
+  font 'Cagliostro-Regular.ttf'
+end

--- a/Casks/font-cambo.rb
+++ b/Casks/font-cambo.rb
@@ -1,0 +1,11 @@
+cask 'font-cambo' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/cambo/Cambo-Regular.ttf'
+  name 'Cambo'
+  homepage 'http://www.google.com/fonts/specimen/Cambo'
+
+  font 'Cambo-Regular.ttf'
+end

--- a/Casks/font-candal.rb
+++ b/Casks/font-candal.rb
@@ -1,0 +1,11 @@
+cask 'font-candal' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/candal/Candal.ttf'
+  name 'Candal'
+  homepage 'http://www.google.com/fonts/specimen/Candal'
+
+  font 'Candal.ttf'
+end

--- a/Casks/font-cantata-one.rb
+++ b/Casks/font-cantata-one.rb
@@ -1,0 +1,11 @@
+cask 'font-cantata-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/cantataone/CantataOne-Regular.ttf'
+  name 'Cantata One'
+  homepage 'http://www.google.com/fonts/specimen/Cantata+One'
+
+  font 'CantataOne-Regular.ttf'
+end

--- a/Casks/font-capriola.rb
+++ b/Casks/font-capriola.rb
@@ -1,0 +1,11 @@
+cask 'font-capriola' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/capriola/Capriola-Regular.ttf'
+  name 'Capriola'
+  homepage 'http://www.google.com/fonts/specimen/Capriola'
+
+  font 'Capriola-Regular.ttf'
+end

--- a/Casks/font-carme.rb
+++ b/Casks/font-carme.rb
@@ -1,0 +1,11 @@
+cask 'font-carme' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/carme/Carme-Regular.ttf'
+  name 'Carme'
+  homepage 'http://www.google.com/fonts/specimen/Carme'
+
+  font 'Carme-Regular.ttf'
+end

--- a/Casks/font-carrois-gothic-sc.rb
+++ b/Casks/font-carrois-gothic-sc.rb
@@ -1,0 +1,11 @@
+cask 'font-carrois-gothic-sc' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/carroisgothicsc/CarroisGothicSC-Regular.ttf'
+  name 'Carrois Gothic SC'
+  homepage 'http://www.google.com/fonts/specimen/Carrois+Gothic+SC'
+
+  font 'CarroisGothicSC-Regular.ttf'
+end

--- a/Casks/font-carrois-gothic.rb
+++ b/Casks/font-carrois-gothic.rb
@@ -1,0 +1,11 @@
+cask 'font-carrois-gothic' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/carroisgothic/CarroisGothic-Regular.ttf'
+  name 'Carrois Gothic'
+  homepage 'http://www.google.com/fonts/specimen/Carrois+Gothic'
+
+  font 'CarroisGothic-Regular.ttf'
+end

--- a/Casks/font-carter-one.rb
+++ b/Casks/font-carter-one.rb
@@ -1,0 +1,11 @@
+cask 'font-carter-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/carterone/CarterOne.ttf'
+  name 'Carter One'
+  homepage 'http://www.google.com/fonts/specimen/Carter+One'
+
+  font 'CarterOne.ttf'
+end

--- a/Casks/font-cedarville-cursive.rb
+++ b/Casks/font-cedarville-cursive.rb
@@ -1,0 +1,11 @@
+cask 'font-cedarville-cursive' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/cedarvillecursive/Cedarville-Cursive.ttf'
+  name 'Cedarville Cursive'
+  homepage 'http://www.google.com/fonts/specimen/Cedarville+Cursive'
+
+  font 'Cedarville-Cursive.ttf'
+end

--- a/Casks/font-ceviche-one.rb
+++ b/Casks/font-ceviche-one.rb
@@ -1,0 +1,11 @@
+cask 'font-ceviche-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/cevicheone/CevicheOne-Regular.ttf'
+  name 'Ceviche One'
+  homepage 'http://www.google.com/fonts/specimen/Ceviche+One'
+
+  font 'CevicheOne-Regular.ttf'
+end

--- a/Casks/font-chango.rb
+++ b/Casks/font-chango.rb
@@ -1,0 +1,11 @@
+cask 'font-chango' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/chango/Chango-Regular.ttf'
+  name 'Chango'
+  homepage 'http://www.google.com/fonts/specimen/Chango'
+
+  font 'Chango-Regular.ttf'
+end

--- a/Casks/font-chela-one.rb
+++ b/Casks/font-chela-one.rb
@@ -1,0 +1,11 @@
+cask 'font-chela-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/chelaone/ChelaOne-Regular.ttf'
+  name 'Chela One'
+  homepage 'http://www.google.com/fonts/specimen/Chela+One'
+
+  font 'ChelaOne-Regular.ttf'
+end

--- a/Casks/font-chelsea-market.rb
+++ b/Casks/font-chelsea-market.rb
@@ -1,0 +1,11 @@
+cask 'font-chelsea-market' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/chelseamarket/ChelseaMarket-Regular.ttf'
+  name 'Chelsea Market'
+  homepage 'http://www.google.com/fonts/specimen/Chelsea+Market'
+
+  font 'ChelseaMarket-Regular.ttf'
+end

--- a/Casks/font-chenla.rb
+++ b/Casks/font-chenla.rb
@@ -1,0 +1,11 @@
+cask 'font-chenla' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/chenla/Chenla.ttf'
+  name 'Chenla'
+  homepage 'http://www.google.com/fonts/specimen/Chenla'
+
+  font 'Chenla.ttf'
+end

--- a/Casks/font-cherry-cream-soda.rb
+++ b/Casks/font-cherry-cream-soda.rb
@@ -1,0 +1,11 @@
+cask 'font-cherry-cream-soda' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/cherrycreamsoda/CherryCreamSoda.ttf'
+  name 'Cherry Cream Soda'
+  homepage 'http://www.google.com/fonts/specimen/Cherry+Cream+Soda'
+
+  font 'CherryCreamSoda.ttf'
+end

--- a/Casks/font-chewy.rb
+++ b/Casks/font-chewy.rb
@@ -1,0 +1,11 @@
+cask 'font-chewy' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/chewy/Chewy.ttf'
+  name 'Chewy'
+  homepage 'http://www.google.com/fonts/specimen/Chewy'
+
+  font 'Chewy.ttf'
+end

--- a/Casks/font-chicle.rb
+++ b/Casks/font-chicle.rb
@@ -1,0 +1,11 @@
+cask 'font-chicle' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/chicle/Chicle-Regular.ttf'
+  name 'Chicle'
+  homepage 'http://www.google.com/fonts/specimen/Chicle'
+
+  font 'Chicle-Regular.ttf'
+end

--- a/Casks/font-clicker-script.rb
+++ b/Casks/font-clicker-script.rb
@@ -1,0 +1,11 @@
+cask 'font-clicker-script' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/clickerscript/ClickerScript-Regular.ttf'
+  name 'Clicker Script'
+  homepage 'http://www.google.com/fonts/specimen/Clicker+Script'
+
+  font 'ClickerScript-Regular.ttf'
+end

--- a/Casks/font-coda-caption.rb
+++ b/Casks/font-coda-caption.rb
@@ -1,0 +1,11 @@
+cask 'font-coda-caption' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/codacaption/CodaCaption-Heavy.ttf'
+  name 'Coda Caption'
+  homepage 'http://www.google.com/fonts/specimen/Coda+Caption'
+
+  font 'CodaCaption-Heavy.ttf'
+end

--- a/Casks/font-combo.rb
+++ b/Casks/font-combo.rb
@@ -1,0 +1,11 @@
+cask 'font-combo' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/combo/Combo-Regular.ttf'
+  name 'Combo'
+  homepage 'http://www.google.com/fonts/specimen/Combo'
+
+  font 'Combo-Regular.ttf'
+end

--- a/Casks/font-concert-one.rb
+++ b/Casks/font-concert-one.rb
@@ -1,0 +1,11 @@
+cask 'font-concert-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/concertone/ConcertOne-Regular.ttf'
+  name 'Concert One'
+  homepage 'http://www.google.com/fonts/specimen/Concert+One'
+
+  font 'ConcertOne-Regular.ttf'
+end

--- a/Casks/font-condiment.rb
+++ b/Casks/font-condiment.rb
@@ -1,0 +1,11 @@
+cask 'font-condiment' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/condiment/Condiment-Regular.ttf'
+  name 'Condiment'
+  homepage 'http://www.google.com/fonts/specimen/Condiment'
+
+  font 'Condiment-Regular.ttf'
+end

--- a/Casks/font-contrail-one.rb
+++ b/Casks/font-contrail-one.rb
@@ -1,0 +1,11 @@
+cask 'font-contrail-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/contrailone/ContrailOne-Regular.ttf'
+  name 'Contrail One'
+  homepage 'http://www.google.com/fonts/specimen/Contrail+One'
+
+  font 'ContrailOne-Regular.ttf'
+end

--- a/Casks/font-convergence.rb
+++ b/Casks/font-convergence.rb
@@ -1,0 +1,11 @@
+cask 'font-convergence' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/convergence/Convergence-Regular.ttf'
+  name 'Convergence'
+  homepage 'http://www.google.com/fonts/specimen/Convergence'
+
+  font 'Convergence-Regular.ttf'
+end

--- a/Casks/font-cookie.rb
+++ b/Casks/font-cookie.rb
@@ -1,0 +1,11 @@
+cask 'font-cookie' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/cookie/Cookie-Regular.ttf'
+  name 'Cookie'
+  homepage 'http://www.google.com/fonts/specimen/Cookie'
+
+  font 'Cookie-Regular.ttf'
+end

--- a/Casks/font-copse.rb
+++ b/Casks/font-copse.rb
@@ -1,0 +1,11 @@
+cask 'font-copse' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/copse/Copse-Regular.ttf'
+  name 'Copse'
+  homepage 'http://www.google.com/fonts/specimen/Copse'
+
+  font 'Copse-Regular.ttf'
+end

--- a/Casks/font-courgette.rb
+++ b/Casks/font-courgette.rb
@@ -1,0 +1,11 @@
+cask 'font-courgette' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/courgette/Courgette-Regular.ttf'
+  name 'Courgette'
+  homepage 'http://www.google.com/fonts/specimen/Courgette'
+
+  font 'Courgette-Regular.ttf'
+end

--- a/Casks/font-covered-by-your-grace.rb
+++ b/Casks/font-covered-by-your-grace.rb
@@ -1,0 +1,11 @@
+cask 'font-covered-by-your-grace' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/coveredbyyourgrace/CoveredByYourGrace.ttf'
+  name 'Covered By Your Grace'
+  homepage 'http://www.google.com/fonts/specimen/Covered+By+Your+Grace'
+
+  font 'CoveredByYourGrace.ttf'
+end

--- a/Casks/font-crafty-girls.rb
+++ b/Casks/font-crafty-girls.rb
@@ -1,0 +1,11 @@
+cask 'font-crafty-girls' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/craftygirls/CraftyGirls.ttf'
+  name 'Crafty Girls'
+  homepage 'http://www.google.com/fonts/specimen/Crafty+Girls'
+
+  font 'CraftyGirls.ttf'
+end

--- a/Casks/font-creepster.rb
+++ b/Casks/font-creepster.rb
@@ -1,0 +1,11 @@
+cask 'font-creepster' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/creepster/Creepster-Regular.ttf'
+  name 'Creepster'
+  homepage 'http://www.google.com/fonts/specimen/Creepster'
+
+  font 'Creepster-Regular.ttf'
+end

--- a/Casks/font-croissant-one.rb
+++ b/Casks/font-croissant-one.rb
@@ -1,0 +1,11 @@
+cask 'font-croissant-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/croissantone/CroissantOne-Regular.ttf'
+  name 'Croissant One'
+  homepage 'http://www.google.com/fonts/specimen/Croissant+One'
+
+  font 'CroissantOne-Regular.ttf'
+end

--- a/Casks/font-crushed.rb
+++ b/Casks/font-crushed.rb
@@ -1,0 +1,11 @@
+cask 'font-crushed' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/crushed/Crushed.ttf'
+  name 'Crushed'
+  homepage 'http://www.google.com/fonts/specimen/Crushed'
+
+  font 'Crushed.ttf'
+end

--- a/Casks/font-damion.rb
+++ b/Casks/font-damion.rb
@@ -1,0 +1,11 @@
+cask 'font-damion' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/damion/Damion-Regular.ttf'
+  name 'Damion'
+  homepage 'http://www.google.com/fonts/specimen/Damion'
+
+  font 'Damion-Regular.ttf'
+end

--- a/Casks/font-dangrek.rb
+++ b/Casks/font-dangrek.rb
@@ -1,0 +1,11 @@
+cask 'font-dangrek' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/dangrek/Dangrek.ttf'
+  name 'Dangrek'
+  homepage 'http://www.google.com/fonts/specimen/Dangrek'
+
+  font 'Dangrek.ttf'
+end

--- a/Casks/font-dawning-of-a-new-day.rb
+++ b/Casks/font-dawning-of-a-new-day.rb
@@ -1,0 +1,11 @@
+cask 'font-dawning-of-a-new-day' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/dawningofanewday/DawningofaNewDay.ttf'
+  name 'Dawning of a New Day'
+  homepage 'http://www.google.com/fonts/specimen/Dawning+of+a+New+Day'
+
+  font 'DawningofaNewDay.ttf'
+end

--- a/Casks/font-days-one.rb
+++ b/Casks/font-days-one.rb
@@ -1,0 +1,11 @@
+cask 'font-days-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/daysone/DaysOne-Regular.ttf'
+  name 'Days One'
+  homepage 'http://www.google.com/fonts/specimen/Days+One'
+
+  font 'DaysOne-Regular.ttf'
+end

--- a/Casks/font-delius-swash-caps.rb
+++ b/Casks/font-delius-swash-caps.rb
@@ -1,0 +1,11 @@
+cask 'font-delius-swash-caps' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/deliusswashcaps/DeliusSwashCaps-Regular.ttf'
+  name 'Delius Swash Caps'
+  homepage 'http://www.google.com/fonts/specimen/Delius+Swash+Caps'
+
+  font 'DeliusSwashCaps-Regular.ttf'
+end

--- a/Casks/font-delius.rb
+++ b/Casks/font-delius.rb
@@ -1,0 +1,11 @@
+cask 'font-delius' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/delius/Delius-Regular.ttf'
+  name 'Delius'
+  homepage 'http://www.google.com/fonts/specimen/Delius'
+
+  font 'Delius-Regular.ttf'
+end

--- a/Casks/font-della-respira.rb
+++ b/Casks/font-della-respira.rb
@@ -1,0 +1,11 @@
+cask 'font-della-respira' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/dellarespira/DellaRespira-Regular.ttf'
+  name 'Della Respira'
+  homepage 'http://www.google.com/fonts/specimen/Della+Respira'
+
+  font 'DellaRespira-Regular.ttf'
+end

--- a/Casks/font-denk-one.rb
+++ b/Casks/font-denk-one.rb
@@ -1,0 +1,11 @@
+cask 'font-denk-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/denkone/DenkOne-Regular.ttf'
+  name 'Denk One'
+  homepage 'http://www.google.com/fonts/specimen/Denk+One'
+
+  font 'DenkOne-Regular.ttf'
+end

--- a/Casks/font-devonshire.rb
+++ b/Casks/font-devonshire.rb
@@ -1,0 +1,11 @@
+cask 'font-devonshire' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/devonshire/Devonshire-Regular.ttf'
+  name 'Devonshire'
+  homepage 'http://www.google.com/fonts/specimen/Devonshire'
+
+  font 'Devonshire-Regular.ttf'
+end

--- a/Casks/font-diplomata-sc.rb
+++ b/Casks/font-diplomata-sc.rb
@@ -1,0 +1,11 @@
+cask 'font-diplomata-sc' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/diplomatasc/DiplomataSC-Regular.ttf'
+  name 'Diplomata SC'
+  homepage 'http://www.google.com/fonts/specimen/Diplomata+SC'
+
+  font 'DiplomataSC-Regular.ttf'
+end

--- a/Casks/font-diplomata.rb
+++ b/Casks/font-diplomata.rb
@@ -1,0 +1,11 @@
+cask 'font-diplomata' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/diplomata/Diplomata-Regular.ttf'
+  name 'Diplomata'
+  homepage 'http://www.google.com/fonts/specimen/Diplomata'
+
+  font 'Diplomata-Regular.ttf'
+end

--- a/Casks/font-donegal-one.rb
+++ b/Casks/font-donegal-one.rb
@@ -1,0 +1,11 @@
+cask 'font-donegal-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/donegalone/DonegalOne-Regular.ttf'
+  name 'Donegal One'
+  homepage 'http://www.google.com/fonts/specimen/Donegal+One'
+
+  font 'DonegalOne-Regular.ttf'
+end

--- a/Casks/font-doppio-one.rb
+++ b/Casks/font-doppio-one.rb
@@ -1,0 +1,11 @@
+cask 'font-doppio-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/doppioone/DoppioOne-Regular.ttf'
+  name 'Doppio One'
+  homepage 'http://www.google.com/fonts/specimen/Doppio+One'
+
+  font 'DoppioOne-Regular.ttf'
+end

--- a/Casks/font-dorsa.rb
+++ b/Casks/font-dorsa.rb
@@ -1,0 +1,11 @@
+cask 'font-dorsa' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/dorsa/Dorsa-Regular.ttf'
+  name 'Dorsa'
+  homepage 'http://www.google.com/fonts/specimen/Dorsa'
+
+  font 'Dorsa-Regular.ttf'
+end

--- a/Casks/font-dr-sugiyama.rb
+++ b/Casks/font-dr-sugiyama.rb
@@ -1,0 +1,11 @@
+cask 'font-dr-sugiyama' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/drsugiyama/DrSugiyama-Regular.ttf'
+  name 'Dr Sugiyama'
+  homepage 'http://www.google.com/fonts/specimen/Dr+Sugiyama'
+
+  font 'DrSugiyama-Regular.ttf'
+end

--- a/Casks/font-duru-sans.rb
+++ b/Casks/font-duru-sans.rb
@@ -1,0 +1,11 @@
+cask 'font-duru-sans' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/durusans/DuruSans-Regular.ttf'
+  name 'Duru Sans'
+  homepage 'http://www.google.com/fonts/specimen/Duru+Sans'
+
+  font 'DuruSans-Regular.ttf'
+end

--- a/Casks/font-dynalight.rb
+++ b/Casks/font-dynalight.rb
@@ -1,0 +1,11 @@
+cask 'font-dynalight' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/dynalight/Dynalight-Regular.ttf'
+  name 'Dynalight'
+  homepage 'http://www.google.com/fonts/specimen/Dynalight'
+
+  font 'Dynalight-Regular.ttf'
+end

--- a/Casks/font-eagle-lake.rb
+++ b/Casks/font-eagle-lake.rb
@@ -1,0 +1,11 @@
+cask 'font-eagle-lake' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/eaglelake/EagleLake-Regular.ttf'
+  name 'Eagle Lake'
+  homepage 'http://www.google.com/fonts/specimen/Eagle+Lake'
+
+  font 'EagleLake-Regular.ttf'
+end

--- a/Casks/font-eater.rb
+++ b/Casks/font-eater.rb
@@ -1,0 +1,11 @@
+cask 'font-eater' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/eater/Eater-Regular.ttf'
+  name 'Eater'
+  homepage 'http://www.google.com/fonts/specimen/Eater'
+
+  font 'Eater-Regular.ttf'
+end

--- a/Casks/font-electrolize.rb
+++ b/Casks/font-electrolize.rb
@@ -1,0 +1,11 @@
+cask 'font-electrolize' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/electrolize/Electrolize-Regular.ttf'
+  name 'Electrolize'
+  homepage 'http://www.google.com/fonts/specimen/Electrolize'
+
+  font 'Electrolize-Regular.ttf'
+end

--- a/Casks/font-emblema-one.rb
+++ b/Casks/font-emblema-one.rb
@@ -1,0 +1,11 @@
+cask 'font-emblema-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/emblemaone/EmblemaOne-Regular.ttf'
+  name 'Emblema One'
+  homepage 'http://www.google.com/fonts/specimen/Emblema+One'
+
+  font 'EmblemaOne-Regular.ttf'
+end

--- a/Casks/font-emilys-candy.rb
+++ b/Casks/font-emilys-candy.rb
@@ -1,0 +1,11 @@
+cask 'font-emilys-candy' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/emilyscandy/EmilysCandy-Regular.ttf'
+  name 'Emilys Candy'
+  homepage 'http://www.google.com/fonts/specimen/Emilys+Candy'
+
+  font 'EmilysCandy-Regular.ttf'
+end

--- a/Casks/font-engagement.rb
+++ b/Casks/font-engagement.rb
@@ -1,0 +1,11 @@
+cask 'font-engagement' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/engagement/Engagement-Regular.ttf'
+  name 'Engagement'
+  homepage 'http://www.google.com/fonts/specimen/Engagement'
+
+  font 'Engagement-Regular.ttf'
+end

--- a/Casks/font-englebert.rb
+++ b/Casks/font-englebert.rb
@@ -1,0 +1,11 @@
+cask 'font-englebert' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/englebert/Englebert-Regular.ttf'
+  name 'Englebert'
+  homepage 'http://www.google.com/fonts/specimen/Englebert'
+
+  font 'Englebert-Regular.ttf'
+end

--- a/Casks/font-erica-one.rb
+++ b/Casks/font-erica-one.rb
@@ -1,0 +1,11 @@
+cask 'font-erica-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/ericaone/EricaOne-Regular.ttf'
+  name 'Erica One'
+  homepage 'http://www.google.com/fonts/specimen/Erica+One'
+
+  font 'EricaOne-Regular.ttf'
+end

--- a/Casks/font-esteban.rb
+++ b/Casks/font-esteban.rb
@@ -1,0 +1,11 @@
+cask 'font-esteban' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/esteban/Esteban-Regular.ttf'
+  name 'Esteban'
+  homepage 'http://www.google.com/fonts/specimen/Esteban'
+
+  font 'Esteban-Regular.ttf'
+end

--- a/Casks/font-euphoria-script.rb
+++ b/Casks/font-euphoria-script.rb
@@ -1,0 +1,11 @@
+cask 'font-euphoria-script' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/euphoriascript/EuphoriaScript-Regular.ttf'
+  name 'Euphoria Script'
+  homepage 'http://www.google.com/fonts/specimen/Euphoria+Script'
+
+  font 'EuphoriaScript-Regular.ttf'
+end

--- a/Casks/font-ewert.rb
+++ b/Casks/font-ewert.rb
@@ -1,0 +1,11 @@
+cask 'font-ewert' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/ewert/Ewert-Regular.ttf'
+  name 'Ewert'
+  homepage 'http://www.google.com/fonts/specimen/Ewert'
+
+  font 'Ewert-Regular.ttf'
+end

--- a/Casks/font-fascinate-inline.rb
+++ b/Casks/font-fascinate-inline.rb
@@ -1,0 +1,11 @@
+cask 'font-fascinate-inline' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/fascinateinline/FascinateInline-Regular.ttf'
+  name 'Fascinate Inline'
+  homepage 'http://www.google.com/fonts/specimen/Fascinate+Inline'
+
+  font 'FascinateInline-Regular.ttf'
+end

--- a/Casks/font-fascinate.rb
+++ b/Casks/font-fascinate.rb
@@ -1,0 +1,11 @@
+cask 'font-fascinate' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/fascinate/Fascinate-Regular.ttf'
+  name 'Fascinate'
+  homepage 'http://www.google.com/fonts/specimen/Fascinate'
+
+  font 'Fascinate-Regular.ttf'
+end

--- a/Casks/font-faster-one.rb
+++ b/Casks/font-faster-one.rb
@@ -1,0 +1,11 @@
+cask 'font-faster-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/fasterone/FasterOne-Regular.ttf'
+  name 'Faster One'
+  homepage 'http://www.google.com/fonts/specimen/Faster+One'
+
+  font 'FasterOne-Regular.ttf'
+end

--- a/Casks/font-fasthand.rb
+++ b/Casks/font-fasthand.rb
@@ -1,0 +1,11 @@
+cask 'font-fasthand' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/fasthand/Fasthand-Regular.ttf'
+  name 'Fasthand'
+  homepage 'http://www.google.com/fonts/specimen/Fasthand'
+
+  font 'Fasthand-Regular.ttf'
+end

--- a/Casks/font-fauna-one.rb
+++ b/Casks/font-fauna-one.rb
@@ -1,0 +1,11 @@
+cask 'font-fauna-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/faunaone/FaunaOne-Regular.ttf'
+  name 'Fauna One'
+  homepage 'http://www.google.com/fonts/specimen/Fauna+One'
+
+  font 'FaunaOne-Regular.ttf'
+end

--- a/Casks/font-federant.rb
+++ b/Casks/font-federant.rb
@@ -1,0 +1,11 @@
+cask 'font-federant' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/federant/Federant-Regular.ttf'
+  name 'Federant'
+  homepage 'http://www.google.com/fonts/specimen/Federant'
+
+  font 'Federant-Regular.ttf'
+end

--- a/Casks/font-federo.rb
+++ b/Casks/font-federo.rb
@@ -1,0 +1,11 @@
+cask 'font-federo' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/federo/Federo-Regular.ttf'
+  name 'Federo'
+  homepage 'http://www.google.com/fonts/specimen/Federo'
+
+  font 'Federo-Regular.ttf'
+end

--- a/Casks/font-felipa.rb
+++ b/Casks/font-felipa.rb
@@ -1,0 +1,11 @@
+cask 'font-felipa' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/felipa/Felipa-Regular.ttf'
+  name 'Felipa'
+  homepage 'http://www.google.com/fonts/specimen/Felipa'
+
+  font 'Felipa-Regular.ttf'
+end

--- a/Casks/font-fenix.rb
+++ b/Casks/font-fenix.rb
@@ -1,0 +1,11 @@
+cask 'font-fenix' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/fenix/Fenix-Regular.ttf'
+  name 'Fenix'
+  homepage 'http://www.google.com/fonts/specimen/Fenix'
+
+  font 'Fenix-Regular.ttf'
+end

--- a/Casks/font-finger-paint.rb
+++ b/Casks/font-finger-paint.rb
@@ -1,0 +1,11 @@
+cask 'font-finger-paint' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/fingerpaint/FingerPaint-Regular.ttf'
+  name 'Finger Paint'
+  homepage 'http://www.google.com/fonts/specimen/Finger+Paint'
+
+  font 'FingerPaint-Regular.ttf'
+end

--- a/Casks/font-fjord-one.rb
+++ b/Casks/font-fjord-one.rb
@@ -1,0 +1,11 @@
+cask 'font-fjord-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/fjordone/FjordOne-Regular.ttf'
+  name 'Fjord One'
+  homepage 'http://www.google.com/fonts/specimen/Fjord+One'
+
+  font 'FjordOne-Regular.ttf'
+end

--- a/Casks/font-flavors.rb
+++ b/Casks/font-flavors.rb
@@ -1,0 +1,11 @@
+cask 'font-flavors' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/flavors/Flavors-Regular.ttf'
+  name 'Flavors'
+  homepage 'http://www.google.com/fonts/specimen/Flavors'
+
+  font 'Flavors-Regular.ttf'
+end

--- a/Casks/font-fontdiner-swanky.rb
+++ b/Casks/font-fontdiner-swanky.rb
@@ -1,0 +1,11 @@
+cask 'font-fontdiner-swanky' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/fontdinerswanky/FontdinerSwanky.ttf'
+  name 'Fontdiner Swanky'
+  homepage 'http://www.google.com/fonts/specimen/Fontdiner+Swanky'
+
+  font 'FontdinerSwanky.ttf'
+end

--- a/Casks/font-forum.rb
+++ b/Casks/font-forum.rb
@@ -1,0 +1,11 @@
+cask 'font-forum' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/forum/Forum-Regular.ttf'
+  name 'Forum'
+  homepage 'http://www.google.com/fonts/specimen/Forum'
+
+  font 'Forum-Regular.ttf'
+end

--- a/Casks/font-francois-one.rb
+++ b/Casks/font-francois-one.rb
@@ -1,0 +1,11 @@
+cask 'font-francois-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/francoisone/FrancoisOne.ttf'
+  name 'Francois One'
+  homepage 'http://www.google.com/fonts/specimen/Francois+One'
+
+  font 'FrancoisOne.ttf'
+end

--- a/Casks/font-freckle-face.rb
+++ b/Casks/font-freckle-face.rb
@@ -1,0 +1,11 @@
+cask 'font-freckle-face' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/freckleface/FreckleFace-Regular.ttf'
+  name 'Freckle Face'
+  homepage 'http://www.google.com/fonts/specimen/Freckle+Face'
+
+  font 'FreckleFace-Regular.ttf'
+end

--- a/Casks/font-fredericka-the-great.rb
+++ b/Casks/font-fredericka-the-great.rb
@@ -1,0 +1,11 @@
+cask 'font-fredericka-the-great' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/frederickathegreat/FrederickatheGreat-Regular.ttf'
+  name 'Fredericka the Great'
+  homepage 'http://www.google.com/fonts/specimen/Fredericka+the+Great'
+
+  font 'FrederickatheGreat-Regular.ttf'
+end

--- a/Casks/font-fredoka-one.rb
+++ b/Casks/font-fredoka-one.rb
@@ -1,0 +1,11 @@
+cask 'font-fredoka-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/fredokaone/FredokaOne-Regular.ttf'
+  name 'Fredoka One'
+  homepage 'http://www.google.com/fonts/specimen/Fredoka+One'
+
+  font 'FredokaOne-Regular.ttf'
+end

--- a/Casks/font-freehand.rb
+++ b/Casks/font-freehand.rb
@@ -1,0 +1,11 @@
+cask 'font-freehand' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/freehand/Freehand.ttf'
+  name 'Freehand'
+  homepage 'http://www.google.com/fonts/specimen/Freehand'
+
+  font 'Freehand.ttf'
+end

--- a/Casks/font-fresca.rb
+++ b/Casks/font-fresca.rb
@@ -1,0 +1,11 @@
+cask 'font-fresca' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/fresca/Fresca-Regular.ttf'
+  name 'Fresca'
+  homepage 'http://www.google.com/fonts/specimen/Fresca'
+
+  font 'Fresca-Regular.ttf'
+end

--- a/Casks/font-frijole.rb
+++ b/Casks/font-frijole.rb
@@ -1,0 +1,11 @@
+cask 'font-frijole' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/frijole/Frijole-Regular.ttf'
+  name 'Frijole'
+  homepage 'http://www.google.com/fonts/specimen/Frijole'
+
+  font 'Frijole-Regular.ttf'
+end

--- a/Casks/font-fruktur.rb
+++ b/Casks/font-fruktur.rb
@@ -1,0 +1,11 @@
+cask 'font-fruktur' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/fruktur/Fruktur-Regular.ttf'
+  name 'Fruktur'
+  homepage 'http://www.google.com/fonts/specimen/Fruktur'
+
+  font 'Fruktur-Regular.ttf'
+end

--- a/Casks/font-fugaz-one.rb
+++ b/Casks/font-fugaz-one.rb
@@ -1,0 +1,11 @@
+cask 'font-fugaz-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/fugazone/FugazOne-Regular.ttf'
+  name 'Fugaz One'
+  homepage 'http://www.google.com/fonts/specimen/Fugaz+One'
+
+  font 'FugazOne-Regular.ttf'
+end

--- a/Casks/font-gabriela.rb
+++ b/Casks/font-gabriela.rb
@@ -1,0 +1,11 @@
+cask 'font-gabriela' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/gabriela/Gabriela-Regular.ttf'
+  name 'Gabriela'
+  homepage 'http://www.google.com/fonts/specimen/Gabriela'
+
+  font 'Gabriela-Regular.ttf'
+end

--- a/Casks/font-gafata.rb
+++ b/Casks/font-gafata.rb
@@ -1,0 +1,11 @@
+cask 'font-gafata' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/gafata/Gafata-Regular.ttf'
+  name 'Gafata'
+  homepage 'http://www.google.com/fonts/specimen/Gafata'
+
+  font 'Gafata-Regular.ttf'
+end

--- a/Casks/font-galdeano.rb
+++ b/Casks/font-galdeano.rb
@@ -1,0 +1,11 @@
+cask 'font-galdeano' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/galdeano/Galdeano-Regular.ttf'
+  name 'Galdeano'
+  homepage 'http://www.google.com/fonts/specimen/Galdeano'
+
+  font 'Galdeano-Regular.ttf'
+end

--- a/Casks/font-galindo.rb
+++ b/Casks/font-galindo.rb
@@ -1,0 +1,11 @@
+cask 'font-galindo' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/galindo/Galindo-Regular.ttf'
+  name 'Galindo'
+  homepage 'http://www.google.com/fonts/specimen/Galindo'
+
+  font 'Galindo-Regular.ttf'
+end

--- a/Casks/font-geostar-fill.rb
+++ b/Casks/font-geostar-fill.rb
@@ -1,0 +1,11 @@
+cask 'font-geostar-fill' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/geostarfill/GeostarFill-Regular.ttf'
+  name 'Geostar Fill'
+  homepage 'http://www.google.com/fonts/specimen/Geostar+Fill'
+
+  font 'GeostarFill-Regular.ttf'
+end

--- a/Casks/font-geostar.rb
+++ b/Casks/font-geostar.rb
@@ -1,0 +1,11 @@
+cask 'font-geostar' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/geostar/Geostar-Regular.ttf'
+  name 'Geostar'
+  homepage 'http://www.google.com/fonts/specimen/Geostar'
+
+  font 'Geostar-Regular.ttf'
+end

--- a/Casks/font-germania-one.rb
+++ b/Casks/font-germania-one.rb
@@ -1,0 +1,11 @@
+cask 'font-germania-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/germaniaone/GermaniaOne-Regular.ttf'
+  name 'Germania One'
+  homepage 'http://www.google.com/fonts/specimen/Germania+One'
+
+  font 'GermaniaOne-Regular.ttf'
+end

--- a/Casks/font-gfs-didot.rb
+++ b/Casks/font-gfs-didot.rb
@@ -1,0 +1,11 @@
+cask 'font-gfs-didot' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/gfsdidot/GFSDidot-Regular.ttf'
+  name 'GFS Didot'
+  homepage 'http://www.google.com/fonts/specimen/GFS+Didot'
+
+  font 'GFSDidot-Regular.ttf'
+end

--- a/Casks/font-gilda-display.rb
+++ b/Casks/font-gilda-display.rb
@@ -1,0 +1,11 @@
+cask 'font-gilda-display' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/gildadisplay/GildaDisplay-Regular.ttf'
+  name 'Gilda Display'
+  homepage 'http://www.google.com/fonts/specimen/Gilda+Display'
+
+  font 'GildaDisplay-Regular.ttf'
+end

--- a/Casks/font-give-you-glory.rb
+++ b/Casks/font-give-you-glory.rb
@@ -1,0 +1,11 @@
+cask 'font-give-you-glory' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/giveyouglory/GiveYouGlory.ttf'
+  name 'Give You Glory'
+  homepage 'http://www.google.com/fonts/specimen/Give+You+Glory'
+
+  font 'GiveYouGlory.ttf'
+end

--- a/Casks/font-glass-antiqua.rb
+++ b/Casks/font-glass-antiqua.rb
@@ -1,0 +1,11 @@
+cask 'font-glass-antiqua' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/glassantiqua/GlassAntiqua-Regular.ttf'
+  name 'Glass Antiqua'
+  homepage 'http://www.google.com/fonts/specimen/Glass+Antiqua'
+
+  font 'GlassAntiqua-Regular.ttf'
+end

--- a/Casks/font-glegoo.rb
+++ b/Casks/font-glegoo.rb
@@ -1,0 +1,14 @@
+cask 'font-glegoo' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/trunk/ofl/glegoo',
+      using:      :svn,
+      trust_cert: true
+  name 'Glegoo'
+  homepage 'http://www.google.com/fonts/specimen/Glegoo'
+
+  font 'Glegoo-Bold.ttf'
+  font 'Glegoo-Regular.ttf'
+end

--- a/Casks/font-gloria-hallelujah.rb
+++ b/Casks/font-gloria-hallelujah.rb
@@ -1,0 +1,11 @@
+cask 'font-gloria-hallelujah' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/gloriahallelujah/GloriaHallelujah.ttf'
+  name 'Gloria Hallelujah'
+  homepage 'http://www.google.com/fonts/specimen/Gloria+Hallelujah'
+
+  font 'GloriaHallelujah.ttf'
+end

--- a/Casks/font-goblin-one.rb
+++ b/Casks/font-goblin-one.rb
@@ -1,0 +1,11 @@
+cask 'font-goblin-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/goblinone/GoblinOne.ttf'
+  name 'Goblin One'
+  homepage 'http://www.google.com/fonts/specimen/Goblin+One'
+
+  font 'GoblinOne.ttf'
+end

--- a/Casks/font-gochi-hand.rb
+++ b/Casks/font-gochi-hand.rb
@@ -1,0 +1,11 @@
+cask 'font-gochi-hand' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/gochihand/GochiHand-Regular.ttf'
+  name 'Gochi Hand'
+  homepage 'http://www.google.com/fonts/specimen/Gochi+Hand'
+
+  font 'GochiHand-Regular.ttf'
+end

--- a/Casks/font-goudy-bookletter1911.rb
+++ b/Casks/font-goudy-bookletter1911.rb
@@ -1,0 +1,11 @@
+cask 'font-goudy-bookletter1911' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/goudybookletter1911/GoudyBookletter1911.ttf'
+  name 'Goudy Bookletter 1911'
+  homepage 'http://www.google.com/fonts/specimen/Goudy+Bookletter+1911'
+
+  font 'GoudyBookletter1911.ttf'
+end

--- a/Casks/font-graduate.rb
+++ b/Casks/font-graduate.rb
@@ -1,0 +1,11 @@
+cask 'font-graduate' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/graduate/Graduate-Regular.ttf'
+  name 'Graduate'
+  homepage 'http://www.google.com/fonts/specimen/Graduate'
+
+  font 'Graduate-Regular.ttf'
+end

--- a/Casks/font-grand-hotel.rb
+++ b/Casks/font-grand-hotel.rb
@@ -1,0 +1,11 @@
+cask 'font-grand-hotel' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/grandhotel/GrandHotel-Regular.ttf'
+  name 'Grand Hotel'
+  homepage 'http://www.google.com/fonts/specimen/Grand+Hotel'
+
+  font 'GrandHotel-Regular.ttf'
+end

--- a/Casks/font-great-vibes.rb
+++ b/Casks/font-great-vibes.rb
@@ -1,0 +1,11 @@
+cask 'font-great-vibes' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/greatvibes/GreatVibes-Regular.ttf'
+  name 'Great Vibes'
+  homepage 'http://www.google.com/fonts/specimen/Great+Vibes'
+
+  font 'GreatVibes-Regular.ttf'
+end

--- a/Casks/font-griffy.rb
+++ b/Casks/font-griffy.rb
@@ -1,0 +1,11 @@
+cask 'font-griffy' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/griffy/Griffy-Regular.ttf'
+  name 'Griffy'
+  homepage 'http://www.google.com/fonts/specimen/Griffy'
+
+  font 'Griffy-Regular.ttf'
+end

--- a/Casks/font-gruppo.rb
+++ b/Casks/font-gruppo.rb
@@ -1,0 +1,11 @@
+cask 'font-gruppo' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/gruppo/Gruppo-Regular.ttf'
+  name 'Gruppo'
+  homepage 'http://www.google.com/fonts/specimen/Gruppo'
+
+  font 'Gruppo-Regular.ttf'
+end

--- a/Casks/font-habibi.rb
+++ b/Casks/font-habibi.rb
@@ -1,0 +1,11 @@
+cask 'font-habibi' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/habibi/Habibi-Regular.ttf'
+  name 'Habibi'
+  homepage 'http://www.google.com/fonts/specimen/Habibi'
+
+  font 'Habibi-Regular.ttf'
+end

--- a/Casks/font-hanalei-fill.rb
+++ b/Casks/font-hanalei-fill.rb
@@ -1,0 +1,11 @@
+cask 'font-hanalei-fill' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/hanaleifill/HanaleiFill-Regular.ttf'
+  name 'Hanalei Fill'
+  homepage 'http://www.google.com/fonts/specimen/Hanalei+Fill'
+
+  font 'HanaleiFill-Regular.ttf'
+end

--- a/Casks/font-hanalei.rb
+++ b/Casks/font-hanalei.rb
@@ -1,0 +1,11 @@
+cask 'font-hanalei' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/hanalei/Hanalei-Regular.ttf'
+  name 'Hanalei'
+  homepage 'http://www.google.com/fonts/specimen/Hanalei'
+
+  font 'Hanalei-Regular.ttf'
+end

--- a/Casks/font-handlee.rb
+++ b/Casks/font-handlee.rb
@@ -1,0 +1,11 @@
+cask 'font-handlee' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/handlee/Handlee-Regular.ttf'
+  name 'Handlee'
+  homepage 'http://www.google.com/fonts/specimen/Handlee'
+
+  font 'Handlee-Regular.ttf'
+end

--- a/Casks/font-happy-monkey.rb
+++ b/Casks/font-happy-monkey.rb
@@ -1,0 +1,11 @@
+cask 'font-happy-monkey' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/happymonkey/HappyMonkey-Regular.ttf'
+  name 'Happy Monkey'
+  homepage 'http://www.google.com/fonts/specimen/Happy+Monkey'
+
+  font 'HappyMonkey-Regular.ttf'
+end

--- a/Casks/font-henny-penny.rb
+++ b/Casks/font-henny-penny.rb
@@ -1,0 +1,11 @@
+cask 'font-henny-penny' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/hennypenny/HennyPenny-Regular.ttf'
+  name 'Henny Penny'
+  homepage 'http://www.google.com/fonts/specimen/Henny+Penny'
+
+  font 'HennyPenny-Regular.ttf'
+end

--- a/Casks/font-herr-von-muellerhoff.rb
+++ b/Casks/font-herr-von-muellerhoff.rb
@@ -1,0 +1,11 @@
+cask 'font-herr-von-muellerhoff' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/herrvonmuellerhoff/HerrVonMuellerhoff-Regular.ttf'
+  name 'Herr Von Muellerhoff'
+  homepage 'http://www.google.com/fonts/specimen/Herr+Von+Muellerhoff'
+
+  font 'HerrVonMuellerhoff-Regular.ttf'
+end

--- a/Casks/font-holtwood-one-sc.rb
+++ b/Casks/font-holtwood-one-sc.rb
@@ -1,0 +1,11 @@
+cask 'font-holtwood-one-sc' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/holtwoodonesc/HoltwoodOneSC.ttf'
+  name 'Holtwood One SC'
+  homepage 'http://www.google.com/fonts/specimen/Holtwood+One+SC'
+
+  font 'HoltwoodOneSC.ttf'
+end

--- a/Casks/font-homemade-apple.rb
+++ b/Casks/font-homemade-apple.rb
@@ -1,0 +1,11 @@
+cask 'font-homemade-apple' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/homemadeapple/HomemadeApple.ttf'
+  name 'Homemade Apple'
+  homepage 'http://www.google.com/fonts/specimen/Homemade+Apple'
+
+  font 'HomemadeApple.ttf'
+end

--- a/Casks/font-homenaje.rb
+++ b/Casks/font-homenaje.rb
@@ -1,0 +1,11 @@
+cask 'font-homenaje' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/homenaje/Homenaje-Regular.ttf'
+  name 'Homenaje'
+  homepage 'http://www.google.com/fonts/specimen/Homenaje'
+
+  font 'Homenaje-Regular.ttf'
+end

--- a/Casks/font-iceberg.rb
+++ b/Casks/font-iceberg.rb
@@ -1,0 +1,11 @@
+cask 'font-iceberg' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/iceberg/Iceberg-Regular.ttf'
+  name 'Iceberg'
+  homepage 'http://www.google.com/fonts/specimen/Iceberg'
+
+  font 'Iceberg-Regular.ttf'
+end

--- a/Casks/font-iceland.rb
+++ b/Casks/font-iceland.rb
@@ -1,0 +1,11 @@
+cask 'font-iceland' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/iceland/Iceland-Regular.ttf'
+  name 'Iceland'
+  homepage 'http://www.google.com/fonts/specimen/Iceland'
+
+  font 'Iceland-Regular.ttf'
+end

--- a/Casks/font-im-fell-double-pica-sc.rb
+++ b/Casks/font-im-fell-double-pica-sc.rb
@@ -1,0 +1,11 @@
+cask 'font-im-fell-double-pica-sc' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/imfelldoublepicasc/IMFeDPsc28P.ttf'
+  name 'IM Fell Double Pica SC'
+  homepage 'http://www.google.com/fonts/specimen/IM+Fell+Double+Pica+SC'
+
+  font 'IMFeDPsc28P.ttf'
+end

--- a/Casks/font-im-fell-dw-pica-sc.rb
+++ b/Casks/font-im-fell-dw-pica-sc.rb
@@ -1,0 +1,11 @@
+cask 'font-im-fell-dw-pica-sc' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/imfelldwpicasc/IMFePIsc28P.ttf'
+  name 'IM Fell DW Pica'
+  homepage 'http://www.google.com/fonts/specimen/IM+Fell+DW+Pica'
+
+  font 'IMFePIsc28P.ttf'
+end

--- a/Casks/font-im-fell-english-sc.rb
+++ b/Casks/font-im-fell-english-sc.rb
@@ -1,0 +1,11 @@
+cask 'font-im-fell-english-sc' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/imfellenglishsc/IMFeENsc28P.ttf'
+  name 'IM Fell English SC'
+  homepage 'http://www.google.com/fonts/specimen/IM+Fell+English+SC'
+
+  font 'IMFeENsc28P.ttf'
+end

--- a/Casks/font-im-fell-french-canon-sc.rb
+++ b/Casks/font-im-fell-french-canon-sc.rb
@@ -1,0 +1,11 @@
+cask 'font-im-fell-french-canon-sc' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/imfellfrenchcanonsc/IMFeFCsc28P.ttf'
+  name 'IM Fell French Canon SC'
+  homepage 'http://www.google.com/fonts/specimen/IM+Fell+French+Canon+SC'
+
+  font 'IMFeFCsc28P.ttf'
+end

--- a/Casks/font-im-fell-great-primer-sc.rb
+++ b/Casks/font-im-fell-great-primer-sc.rb
@@ -1,0 +1,11 @@
+cask 'font-im-fell-great-primer-sc' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/imfellgreatprimersc/IMFeGPsc28P.ttf'
+  name 'IM Fell Great Primer SC'
+  homepage 'http://www.google.com/fonts/specimen/IM+Fell+Great+Primer+SC'
+
+  font 'IMFeGPsc28P.ttf'
+end

--- a/Casks/font-imprima.rb
+++ b/Casks/font-imprima.rb
@@ -1,0 +1,11 @@
+cask 'font-imprima' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/imprima/Imprima-Regular.ttf'
+  name 'Imprima'
+  homepage 'http://www.google.com/fonts/specimen/Imprima'
+
+  font 'Imprima-Regular.ttf'
+end

--- a/Casks/font-inder.rb
+++ b/Casks/font-inder.rb
@@ -1,0 +1,11 @@
+cask 'font-inder' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/inder/Inder-Regular.ttf'
+  name 'Inder'
+  homepage 'http://www.google.com/fonts/specimen/Inder'
+
+  font 'Inder-Regular.ttf'
+end

--- a/Casks/font-indie-flower.rb
+++ b/Casks/font-indie-flower.rb
@@ -1,0 +1,11 @@
+cask 'font-indie-flower' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/indieflower/IndieFlower-Regular.ttf'
+  name 'Indie Flower'
+  homepage 'http://www.google.com/fonts/specimen/Indie+Flower'
+
+  font 'IndieFlower-Regular.ttf'
+end

--- a/Casks/font-irish-grover.rb
+++ b/Casks/font-irish-grover.rb
@@ -1,0 +1,11 @@
+cask 'font-irish-grover' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/irishgrover/IrishGrover.ttf'
+  name 'Irish Grover'
+  homepage 'http://www.google.com/fonts/specimen/Irish+Grover'
+
+  font 'IrishGrover.ttf'
+end

--- a/Casks/font-italiana.rb
+++ b/Casks/font-italiana.rb
@@ -1,0 +1,11 @@
+cask 'font-italiana' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/italiana/Italiana-Regular.ttf'
+  name 'Italiana'
+  homepage 'http://www.google.com/fonts/specimen/Italiana'
+
+  font 'Italiana-Regular.ttf'
+end

--- a/Casks/font-italianno.rb
+++ b/Casks/font-italianno.rb
@@ -1,0 +1,11 @@
+cask 'font-italianno' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/italianno/Italianno-Regular.ttf'
+  name 'Italianno'
+  homepage 'http://www.google.com/fonts/specimen/Italianno'
+
+  font 'Italianno-Regular.ttf'
+end

--- a/Casks/font-jacques-francois-shadow.rb
+++ b/Casks/font-jacques-francois-shadow.rb
@@ -1,0 +1,11 @@
+cask 'font-jacques-francois-shadow' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/jacquesfrancoisshadow/JacquesFrancoisShadow-Regular.ttf'
+  name 'Jacques Francois Shadow'
+  homepage 'http://www.google.com/fonts/specimen/Jacques+Francois+Shadow'
+
+  font 'JacquesFrancoisShadow-Regular.ttf'
+end

--- a/Casks/font-jacques-francois.rb
+++ b/Casks/font-jacques-francois.rb
@@ -1,0 +1,11 @@
+cask 'font-jacques-francois' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/jacquesfrancois/JacquesFrancois-Regular.ttf'
+  name 'Jacques Francois'
+  homepage 'http://www.google.com/fonts/specimen/Jacques+Francois'
+
+  font 'JacquesFrancois-Regular.ttf'
+end

--- a/Casks/font-jim-nightshade.rb
+++ b/Casks/font-jim-nightshade.rb
@@ -1,0 +1,11 @@
+cask 'font-jim-nightshade' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/jimnightshade/JimNightshade-Regular.ttf'
+  name 'Jim Nightshade'
+  homepage 'http://www.google.com/fonts/specimen/Jim+Nightshade'
+
+  font 'JimNightshade-Regular.ttf'
+end

--- a/Casks/font-jockey-one.rb
+++ b/Casks/font-jockey-one.rb
@@ -1,0 +1,11 @@
+cask 'font-jockey-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/jockeyone/JockeyOne-Regular.ttf'
+  name 'Jockey One'
+  homepage 'http://www.google.com/fonts/specimen/Jockey+One'
+
+  font 'JockeyOne-Regular.ttf'
+end

--- a/Casks/font-jolly-lodger.rb
+++ b/Casks/font-jolly-lodger.rb
@@ -1,0 +1,11 @@
+cask 'font-jolly-lodger' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/jollylodger/JollyLodger-Regular.ttf'
+  name 'Jolly Lodger'
+  homepage 'http://www.google.com/fonts/specimen/Jolly+Lodger'
+
+  font 'JollyLodger-Regular.ttf'
+end

--- a/Casks/font-joti-one.rb
+++ b/Casks/font-joti-one.rb
@@ -1,0 +1,11 @@
+cask 'font-joti-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/jotione/JotiOne-Regular.ttf'
+  name 'Joti One'
+  homepage 'http://www.google.com/fonts/specimen/Joti+One'
+
+  font 'JotiOne-Regular.ttf'
+end

--- a/Casks/font-julee.rb
+++ b/Casks/font-julee.rb
@@ -1,0 +1,11 @@
+cask 'font-julee' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/julee/Julee-Regular.ttf'
+  name 'Julee'
+  homepage 'http://www.google.com/fonts/specimen/Julee'
+
+  font 'Julee-Regular.ttf'
+end

--- a/Casks/font-julius-sans-one.rb
+++ b/Casks/font-julius-sans-one.rb
@@ -1,0 +1,11 @@
+cask 'font-julius-sans-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/juliussansone/JuliusSansOne-Regular.ttf'
+  name 'Julius Sans One'
+  homepage 'http://www.google.com/fonts/specimen/Julius+Sans+One'
+
+  font 'JuliusSansOne-Regular.ttf'
+end

--- a/Casks/font-junge.rb
+++ b/Casks/font-junge.rb
@@ -1,0 +1,11 @@
+cask 'font-junge' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/junge/Junge-Regular.ttf'
+  name 'Junge'
+  homepage 'http://www.google.com/fonts/specimen/Junge'
+
+  font 'Junge-Regular.ttf'
+end

--- a/Casks/font-just-another-hand.rb
+++ b/Casks/font-just-another-hand.rb
@@ -1,0 +1,11 @@
+cask 'font-just-another-hand' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/justanotherhand/JustAnotherHand.ttf'
+  name 'Just Another Hand'
+  homepage 'http://www.google.com/fonts/specimen/Just+Another+Hand'
+
+  font 'JustAnotherHand.ttf'
+end

--- a/Casks/font-just-me-again-down-here.rb
+++ b/Casks/font-just-me-again-down-here.rb
@@ -1,0 +1,11 @@
+cask 'font-just-me-again-down-here' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/justmeagaindownhere/JustMeAgainDownHere.ttf'
+  name 'Just Me Again Down Here'
+  homepage 'http://www.google.com/fonts/specimen/Just+Me+Again+Down+Here'
+
+  font 'JustMeAgainDownHere.ttf'
+end

--- a/Casks/font-kaushan-script.rb
+++ b/Casks/font-kaushan-script.rb
@@ -1,0 +1,11 @@
+cask 'font-kaushan-script' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/kaushanscript/KaushanScript-Regular.ttf'
+  name 'Kaushan Script'
+  homepage 'http://www.google.com/fonts/specimen/Kaushan+Script'
+
+  font 'KaushanScript-Regular.ttf'
+end

--- a/Casks/font-kavoon.rb
+++ b/Casks/font-kavoon.rb
@@ -1,0 +1,11 @@
+cask 'font-kavoon' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/kavoon/Kavoon-Regular.ttf'
+  name 'Kavoon'
+  homepage 'http://www.google.com/fonts/specimen/Kavoon'
+
+  font 'Kavoon-Regular.ttf'
+end

--- a/Casks/font-kdam-thmor.rb
+++ b/Casks/font-kdam-thmor.rb
@@ -1,0 +1,11 @@
+cask 'font-kdam-thmor' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/kdamthmor/KdamThmor-Regular.ttf'
+  name 'Kdam Thmor'
+  homepage 'http://www.google.com/fonts/specimen/Kdam+Thmor'
+
+  font 'KdamThmor-Regular.ttf'
+end

--- a/Casks/font-keania-one.rb
+++ b/Casks/font-keania-one.rb
@@ -1,0 +1,11 @@
+cask 'font-keania-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/keaniaone/KeaniaOne-Regular.ttf'
+  name 'Keania One'
+  homepage 'http://www.google.com/fonts/specimen/Keania+One'
+
+  font 'KeaniaOne-Regular.ttf'
+end

--- a/Casks/font-kelly-slab.rb
+++ b/Casks/font-kelly-slab.rb
@@ -1,0 +1,11 @@
+cask 'font-kelly-slab' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/kellyslab/KellySlab-Regular.ttf'
+  name 'Kelly Slab'
+  homepage 'http://www.google.com/fonts/specimen/Kelly+Slab'
+
+  font 'KellySlab-Regular.ttf'
+end

--- a/Casks/font-kenia.rb
+++ b/Casks/font-kenia.rb
@@ -1,0 +1,11 @@
+cask 'font-kenia' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/kenia/Kenia-Regular.ttf'
+  name 'Kenia'
+  homepage 'http://www.google.com/fonts/specimen/Kenia'
+
+  font 'Kenia-Regular.ttf'
+end

--- a/Casks/font-khmer.rb
+++ b/Casks/font-khmer.rb
@@ -1,0 +1,11 @@
+cask 'font-khmer' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/khmer/Khmer.ttf'
+  name 'Khmer'
+  homepage 'http://www.google.com/fonts/specimen/Khmer'
+
+  font 'Khmer.ttf'
+end

--- a/Casks/font-kite-one.rb
+++ b/Casks/font-kite-one.rb
@@ -1,0 +1,11 @@
+cask 'font-kite-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/kiteone/KiteOne-Regular.ttf'
+  name 'Kite One'
+  homepage 'http://www.google.com/fonts/specimen/Kite+One'
+
+  font 'KiteOne-Regular.ttf'
+end

--- a/Casks/font-knewave.rb
+++ b/Casks/font-knewave.rb
@@ -1,0 +1,11 @@
+cask 'font-knewave' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/knewave/Knewave-Regular.ttf'
+  name 'Knewave'
+  homepage 'http://www.google.com/fonts/specimen/Knewave'
+
+  font 'Knewave-Regular.ttf'
+end

--- a/Casks/font-kotta-one.rb
+++ b/Casks/font-kotta-one.rb
@@ -1,0 +1,11 @@
+cask 'font-kotta-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/kottaone/KottaOne-Regular.ttf'
+  name 'Kotta One'
+  homepage 'http://www.google.com/fonts/specimen/Kotta+One'
+
+  font 'KottaOne-Regular.ttf'
+end

--- a/Casks/font-koulen.rb
+++ b/Casks/font-koulen.rb
@@ -1,0 +1,11 @@
+cask 'font-koulen' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/koulen/Koulen.ttf'
+  name 'Koulen'
+  homepage 'http://www.google.com/fonts/specimen/Koulen'
+
+  font 'Koulen.ttf'
+end

--- a/Casks/font-kranky.rb
+++ b/Casks/font-kranky.rb
@@ -1,0 +1,11 @@
+cask 'font-kranky' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/kranky/Kranky.ttf'
+  name 'Kranky'
+  homepage 'http://www.google.com/fonts/specimen/Kranky'
+
+  font 'Kranky.ttf'
+end

--- a/Casks/font-kristi.rb
+++ b/Casks/font-kristi.rb
@@ -1,0 +1,11 @@
+cask 'font-kristi' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/kristi/Kristi.ttf'
+  name 'Kristi'
+  homepage 'http://www.google.com/fonts/specimen/Kristi'
+
+  font 'Kristi.ttf'
+end

--- a/Casks/font-krona-one.rb
+++ b/Casks/font-krona-one.rb
@@ -1,0 +1,11 @@
+cask 'font-krona-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/kronaone/KronaOne-Regular.ttf'
+  name 'Krona One'
+  homepage 'http://www.google.com/fonts/specimen/Krona+One'
+
+  font 'KronaOne-Regular.ttf'
+end

--- a/Casks/font-la-belle-aurore.rb
+++ b/Casks/font-la-belle-aurore.rb
@@ -1,0 +1,11 @@
+cask 'font-la-belle-aurore' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/labelleaurore/LaBelleAurore.ttf'
+  name 'La Belle Aurore'
+  homepage 'http://www.google.com/fonts/specimen/La+Belle+Aurore'
+
+  font 'LaBelleAurore.ttf'
+end

--- a/Casks/font-lancelot.rb
+++ b/Casks/font-lancelot.rb
@@ -1,0 +1,11 @@
+cask 'font-lancelot' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/lancelot/Lancelot-Regular.ttf'
+  name 'Lancelot'
+  homepage 'http://www.google.com/fonts/specimen/Lancelot'
+
+  font 'Lancelot-Regular.ttf'
+end

--- a/Casks/font-lateef.rb
+++ b/Casks/font-lateef.rb
@@ -1,0 +1,11 @@
+cask 'font-lateef' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/lateef/LateefRegOT.ttf'
+  name 'Lateef'
+  homepage 'http://www.google.com/fonts/specimen/Lateef'
+
+  font 'LateefRegOT.ttf'
+end

--- a/Casks/font-league-script.rb
+++ b/Casks/font-league-script.rb
@@ -1,0 +1,11 @@
+cask 'font-league-script' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/leaguescript/LeagueScript.ttf'
+  name 'League Script'
+  homepage 'http://www.google.com/fonts/specimen/League+Script'
+
+  font 'LeagueScript.ttf'
+end

--- a/Casks/font-leckerli-one.rb
+++ b/Casks/font-leckerli-one.rb
@@ -1,0 +1,11 @@
+cask 'font-leckerli-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/leckerlione/LeckerliOne-Regular.ttf'
+  name 'Leckerli One'
+  homepage 'http://www.google.com/fonts/specimen/Leckerli+One'
+
+  font 'LeckerliOne-Regular.ttf'
+end

--- a/Casks/font-lemon.rb
+++ b/Casks/font-lemon.rb
@@ -1,0 +1,11 @@
+cask 'font-lemon' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/lemon/Lemon-Regular.ttf'
+  name 'Lemon'
+  homepage 'http://www.google.com/fonts/specimen/Lemon'
+
+  font 'Lemon-Regular.ttf'
+end

--- a/Casks/font-lilita-one.rb
+++ b/Casks/font-lilita-one.rb
@@ -1,0 +1,11 @@
+cask 'font-lilita-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/lilitaone/LilitaOne-Regular.ttf'
+  name 'Lilita One'
+  homepage 'http://www.google.com/fonts/specimen/Lilita+One'
+
+  font 'LilitaOne-Regular.ttf'
+end

--- a/Casks/font-lily-script-one.rb
+++ b/Casks/font-lily-script-one.rb
@@ -1,0 +1,11 @@
+cask 'font-lily-script-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/lilyscriptone/LilyScriptOne-Regular.ttf'
+  name 'Lily Script One'
+  homepage 'http://www.google.com/fonts/specimen/Lily+Script+One'
+
+  font 'LilyScriptOne-Regular.ttf'
+end

--- a/Casks/font-limelight.rb
+++ b/Casks/font-limelight.rb
@@ -1,0 +1,11 @@
+cask 'font-limelight' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/limelight/Limelight-Regular.ttf'
+  name 'Limelight'
+  homepage 'http://www.google.com/fonts/specimen/Limelight'
+
+  font 'Limelight-Regular.ttf'
+end

--- a/Casks/font-londrina-outline.rb
+++ b/Casks/font-londrina-outline.rb
@@ -1,0 +1,11 @@
+cask 'font-londrina-outline' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/londrinaoutline/LondrinaOutline-Regular.ttf'
+  name 'Londrina Outline'
+  homepage 'http://www.google.com/fonts/specimen/Londrina+Outline'
+
+  font 'LondrinaOutline-Regular.ttf'
+end

--- a/Casks/font-londrina-shadow.rb
+++ b/Casks/font-londrina-shadow.rb
@@ -1,0 +1,11 @@
+cask 'font-londrina-shadow' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/londrinashadow/LondrinaShadow-Regular.ttf'
+  name 'Londrina Shadow'
+  homepage 'http://www.google.com/fonts/specimen/Londrina+Shadow'
+
+  font 'LondrinaShadow-Regular.ttf'
+end

--- a/Casks/font-londrina-sketch.rb
+++ b/Casks/font-londrina-sketch.rb
@@ -1,0 +1,11 @@
+cask 'font-londrina-sketch' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/londrinasketch/LondrinaSketch-Regular.ttf'
+  name 'Londrina Sketch'
+  homepage 'http://www.google.com/fonts/specimen/Londrina+Sketch'
+
+  font 'LondrinaSketch-Regular.ttf'
+end

--- a/Casks/font-londrina-solid.rb
+++ b/Casks/font-londrina-solid.rb
@@ -1,0 +1,11 @@
+cask 'font-londrina-solid' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/londrinasolid/LondrinaSolid-Regular.ttf'
+  name 'Londrina Solid'
+  homepage 'http://www.google.com/fonts/specimen/Londrina+Solid'
+
+  font 'LondrinaSolid-Regular.ttf'
+end

--- a/Casks/font-love-ya-like-a-sister.rb
+++ b/Casks/font-love-ya-like-a-sister.rb
@@ -1,0 +1,11 @@
+cask 'font-love-ya-like-a-sister' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/loveyalikeasister/LoveYaLikeASister.ttf'
+  name 'Love Ya Like A Sister'
+  homepage 'http://www.google.com/fonts/specimen/Love+Ya+Like+A+Sister'
+
+  font 'LoveYaLikeASister.ttf'
+end

--- a/Casks/font-loved-by-the-king.rb
+++ b/Casks/font-loved-by-the-king.rb
@@ -1,0 +1,11 @@
+cask 'font-loved-by-the-king' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/lovedbytheking/LovedbytheKing.ttf'
+  name 'Loved by the King'
+  homepage 'http://www.google.com/fonts/specimen/Loved+by+the+King'
+
+  font 'LovedbytheKing.ttf'
+end

--- a/Casks/font-lovers-quarrel.rb
+++ b/Casks/font-lovers-quarrel.rb
@@ -1,0 +1,11 @@
+cask 'font-lovers-quarrel' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/loversquarrel/LoversQuarrel-Regular.ttf'
+  name 'Lovers Quarrel'
+  homepage 'http://www.google.com/fonts/specimen/Lovers+Quarrel'
+
+  font 'LoversQuarrel-Regular.ttf'
+end

--- a/Casks/font-luckiest-guy.rb
+++ b/Casks/font-luckiest-guy.rb
@@ -1,0 +1,11 @@
+cask 'font-luckiest-guy' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/luckiestguy/LuckiestGuy.ttf'
+  name 'Luckiest Guy'
+  homepage 'http://www.google.com/fonts/specimen/Luckiest+Guy'
+
+  font 'LuckiestGuy.ttf'
+end

--- a/Casks/font-lustria.rb
+++ b/Casks/font-lustria.rb
@@ -1,0 +1,11 @@
+cask 'font-lustria' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/lustria/Lustria-Regular.ttf'
+  name 'Lustria'
+  homepage 'http://www.google.com/fonts/specimen/Lustria'
+
+  font 'Lustria-Regular.ttf'
+end

--- a/Casks/font-macondo-swash-caps.rb
+++ b/Casks/font-macondo-swash-caps.rb
@@ -1,0 +1,11 @@
+cask 'font-macondo-swash-caps' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/macondoswashcaps/MacondoSwashCaps-Regular.ttf'
+  name 'Macondo Swash Caps'
+  homepage 'http://www.google.com/fonts/specimen/Macondo+Swash+Caps'
+
+  font 'MacondoSwashCaps-Regular.ttf'
+end

--- a/Casks/font-macondo.rb
+++ b/Casks/font-macondo.rb
@@ -1,0 +1,11 @@
+cask 'font-macondo' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/macondo/Macondo-Regular.ttf'
+  name 'Macondo'
+  homepage 'http://www.google.com/fonts/specimen/Macondo'
+
+  font 'Macondo-Regular.ttf'
+end

--- a/Casks/font-maiden-orange.rb
+++ b/Casks/font-maiden-orange.rb
@@ -1,0 +1,11 @@
+cask 'font-maiden-orange' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/maidenorange/MaidenOrange.ttf'
+  name 'Maiden Orange'
+  homepage 'http://www.google.com/fonts/specimen/Maiden+Orange'
+
+  font 'MaidenOrange.ttf'
+end

--- a/Casks/font-mako.rb
+++ b/Casks/font-mako.rb
@@ -1,0 +1,11 @@
+cask 'font-mako' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/mako/Mako-Regular.ttf'
+  name 'Mako'
+  homepage 'http://www.google.com/fonts/specimen/Mako'
+
+  font 'Mako-Regular.ttf'
+end

--- a/Casks/font-marcellus-sc.rb
+++ b/Casks/font-marcellus-sc.rb
@@ -1,0 +1,11 @@
+cask 'font-marcellus-sc' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/marcellussc/MarcellusSC-Regular.ttf'
+  name 'Marcellus SC'
+  homepage 'http://www.google.com/fonts/specimen/Marcellus+SC'
+
+  font 'MarcellusSC-Regular.ttf'
+end

--- a/Casks/font-marcellus.rb
+++ b/Casks/font-marcellus.rb
@@ -1,0 +1,11 @@
+cask 'font-marcellus' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/marcellus/Marcellus-Regular.ttf'
+  name 'Marcellus'
+  homepage 'http://www.google.com/fonts/specimen/Marcellus'
+
+  font 'Marcellus-Regular.ttf'
+end

--- a/Casks/font-marck-script.rb
+++ b/Casks/font-marck-script.rb
@@ -1,0 +1,11 @@
+cask 'font-marck-script' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/marckscript/MarckScript-Regular.ttf'
+  name 'Marck Script'
+  homepage 'http://www.google.com/fonts/specimen/Marck+Script'
+
+  font 'MarckScript-Regular.ttf'
+end

--- a/Casks/font-margarine.rb
+++ b/Casks/font-margarine.rb
@@ -1,0 +1,11 @@
+cask 'font-margarine' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/margarine/Margarine-Regular.ttf'
+  name 'Margarine'
+  homepage 'http://www.google.com/fonts/specimen/Margarine'
+
+  font 'Margarine-Regular.ttf'
+end

--- a/Casks/font-marko-one.rb
+++ b/Casks/font-marko-one.rb
@@ -1,0 +1,11 @@
+cask 'font-marko-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/markoone/MarkoOne-Regular.ttf'
+  name 'Marko One'
+  homepage 'http://www.google.com/fonts/specimen/Marko+One'
+
+  font 'MarkoOne-Regular.ttf'
+end

--- a/Casks/font-marmelad.rb
+++ b/Casks/font-marmelad.rb
@@ -1,0 +1,11 @@
+cask 'font-marmelad' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/marmelad/Marmelad-Regular.ttf'
+  name 'Marmelad'
+  homepage 'http://www.google.com/fonts/specimen/Marmelad'
+
+  font 'Marmelad-Regular.ttf'
+end

--- a/Casks/font-mate-sc.rb
+++ b/Casks/font-mate-sc.rb
@@ -1,0 +1,11 @@
+cask 'font-mate-sc' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/matesc/MateSC-Regular.ttf'
+  name 'Mate SC'
+  homepage 'http://www.google.com/fonts/specimen/Mate+SC'
+
+  font 'MateSC-Regular.ttf'
+end

--- a/Casks/font-mclaren.rb
+++ b/Casks/font-mclaren.rb
@@ -1,0 +1,11 @@
+cask 'font-mclaren' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/mclaren/McLaren-Regular.ttf'
+  name 'McLaren'
+  homepage 'http://www.google.com/fonts/specimen/McLaren'
+
+  font 'McLaren-Regular.ttf'
+end

--- a/Casks/font-meddon.rb
+++ b/Casks/font-meddon.rb
@@ -1,0 +1,11 @@
+cask 'font-meddon' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/meddon/Meddon.ttf'
+  name 'Meddon'
+  homepage 'http://www.google.com/fonts/specimen/Meddon'
+
+  font 'Meddon.ttf'
+end

--- a/Casks/font-medievalsharp.rb
+++ b/Casks/font-medievalsharp.rb
@@ -1,0 +1,11 @@
+cask 'font-medievalsharp' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/medievalsharp/MedievalSharp.ttf'
+  name 'MedievalSharp'
+  homepage 'http://www.google.com/fonts/specimen/MedievalSharp'
+
+  font 'MedievalSharp.ttf'
+end

--- a/Casks/font-medula-one.rb
+++ b/Casks/font-medula-one.rb
@@ -1,0 +1,11 @@
+cask 'font-medula-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/medulaone/MedulaOne-Regular.ttf'
+  name 'Medula One'
+  homepage 'http://www.google.com/fonts/specimen/Medula+One'
+
+  font 'MedulaOne-Regular.ttf'
+end

--- a/Casks/font-megrim.rb
+++ b/Casks/font-megrim.rb
@@ -1,0 +1,11 @@
+cask 'font-megrim' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/megrim/Megrim.ttf'
+  name 'Megrim'
+  homepage 'http://www.google.com/fonts/specimen/Megrim'
+
+  font 'Megrim.ttf'
+end

--- a/Casks/font-meie-script.rb
+++ b/Casks/font-meie-script.rb
@@ -1,0 +1,11 @@
+cask 'font-meie-script' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/meiescript/MeieScript-Regular.ttf'
+  name 'Meie Script'
+  homepage 'http://www.google.com/fonts/specimen/Meie+Script'
+
+  font 'MeieScript-Regular.ttf'
+end

--- a/Casks/font-merienda-one.rb
+++ b/Casks/font-merienda-one.rb
@@ -1,0 +1,11 @@
+cask 'font-merienda-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/meriendaone/MeriendaOne-Regular.ttf'
+  name 'Merienda One'
+  homepage 'http://www.google.com/fonts/specimen/Merienda+One'
+
+  font 'MeriendaOne-Regular.ttf'
+end

--- a/Casks/font-metal-mania.rb
+++ b/Casks/font-metal-mania.rb
@@ -1,0 +1,11 @@
+cask 'font-metal-mania' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/metalmania/MetalMania-Regular.ttf'
+  name 'Metal Mania'
+  homepage 'http://www.google.com/fonts/specimen/Metal+Mania'
+
+  font 'MetalMania-Regular.ttf'
+end

--- a/Casks/font-metal.rb
+++ b/Casks/font-metal.rb
@@ -1,0 +1,11 @@
+cask 'font-metal' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/metal/Metal.ttf'
+  name 'Metal'
+  homepage 'http://www.google.com/fonts/specimen/Metal'
+
+  font 'Metal.ttf'
+end

--- a/Casks/font-metamorphous.rb
+++ b/Casks/font-metamorphous.rb
@@ -1,0 +1,11 @@
+cask 'font-metamorphous' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/metamorphous/Metamorphous-Regular.ttf'
+  name 'Metamorphous'
+  homepage 'http://www.google.com/fonts/specimen/Metamorphous'
+
+  font 'Metamorphous-Regular.ttf'
+end

--- a/Casks/font-metrophobic.rb
+++ b/Casks/font-metrophobic.rb
@@ -1,0 +1,11 @@
+cask 'font-metrophobic' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/metrophobic/Metrophobic.ttf'
+  name 'Metrophobic'
+  homepage 'http://www.google.com/fonts/specimen/Metrophobic'
+
+  font 'Metrophobic.ttf'
+end

--- a/Casks/font-michroma.rb
+++ b/Casks/font-michroma.rb
@@ -1,0 +1,11 @@
+cask 'font-michroma' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/michroma/Michroma.ttf'
+  name 'Michroma'
+  homepage 'http://www.google.com/fonts/specimen/Michroma'
+
+  font 'Michroma.ttf'
+end

--- a/Casks/font-milonga.rb
+++ b/Casks/font-milonga.rb
@@ -1,0 +1,11 @@
+cask 'font-milonga' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/milonga/Milonga-Regular.ttf'
+  name 'Milonga'
+  homepage 'http://www.google.com/fonts/specimen/Milonga'
+
+  font 'Milonga-Regular.ttf'
+end

--- a/Casks/font-miltonian-tattoo.rb
+++ b/Casks/font-miltonian-tattoo.rb
@@ -1,0 +1,11 @@
+cask 'font-miltonian-tattoo' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/miltoniantattoo/MiltonianTattoo-Regular.ttf'
+  name 'Miltonian Tattoo'
+  homepage 'http://www.google.com/fonts/specimen/Miltonian+Tattoo'
+
+  font 'MiltonianTattoo-Regular.ttf'
+end

--- a/Casks/font-miltonian.rb
+++ b/Casks/font-miltonian.rb
@@ -1,0 +1,11 @@
+cask 'font-miltonian' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/miltonian/Miltonian-Regular.ttf'
+  name 'Miltonian'
+  homepage 'http://www.google.com/fonts/specimen/Miltonian'
+
+  font 'Miltonian-Regular.ttf'
+end

--- a/Casks/font-miniver.rb
+++ b/Casks/font-miniver.rb
@@ -1,0 +1,11 @@
+cask 'font-miniver' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/miniver/Miniver-Regular.ttf'
+  name 'Miniver'
+  homepage 'http://www.google.com/fonts/specimen/Miniver'
+
+  font 'Miniver-Regular.ttf'
+end

--- a/Casks/font-miss-fajardose.rb
+++ b/Casks/font-miss-fajardose.rb
@@ -1,0 +1,11 @@
+cask 'font-miss-fajardose' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/missfajardose/MissFajardose-Regular.ttf'
+  name 'Miss Fajardose'
+  homepage 'http://www.google.com/fonts/specimen/Miss+Fajardose'
+
+  font 'MissFajardose-Regular.ttf'
+end

--- a/Casks/font-modern-antiqua.rb
+++ b/Casks/font-modern-antiqua.rb
@@ -1,0 +1,11 @@
+cask 'font-modern-antiqua' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/modernantiqua/ModernAntiqua-Regular.ttf'
+  name 'Modern Antiqua'
+  homepage 'http://www.google.com/fonts/specimen/Modern+Antiqua'
+
+  font 'ModernAntiqua-Regular.ttf'
+end

--- a/Casks/font-molengo.rb
+++ b/Casks/font-molengo.rb
@@ -1,0 +1,11 @@
+cask 'font-molengo' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/molengo/Molengo-Regular.ttf'
+  name 'Molengo'
+  homepage 'http://www.google.com/fonts/specimen/Molengo'
+
+  font 'Molengo-Regular.ttf'
+end

--- a/Casks/font-molle.rb
+++ b/Casks/font-molle.rb
@@ -1,0 +1,11 @@
+cask 'font-molle' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/molle/Molle-Regular.ttf'
+  name 'Molle'
+  homepage 'http://www.google.com/fonts/specimen/Molle'
+
+  font 'Molle-Regular.ttf'
+end

--- a/Casks/font-monofett.rb
+++ b/Casks/font-monofett.rb
@@ -1,0 +1,11 @@
+cask 'font-monofett' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/monofett/Monofett.ttf'
+  name 'Monofett'
+  homepage 'http://www.google.com/fonts/specimen/Monofett'
+
+  font 'Monofett.ttf'
+end

--- a/Casks/font-monoton.rb
+++ b/Casks/font-monoton.rb
@@ -1,0 +1,11 @@
+cask 'font-monoton' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/monoton/Monoton-Regular.ttf'
+  name 'Monoton'
+  homepage 'http://www.google.com/fonts/specimen/Monoton'
+
+  font 'Monoton-Regular.ttf'
+end

--- a/Casks/font-monsieur-la-doulaise.rb
+++ b/Casks/font-monsieur-la-doulaise.rb
@@ -1,0 +1,11 @@
+cask 'font-monsieur-la-doulaise' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/monsieurladoulaise/MonsieurLaDoulaise-Regular.ttf'
+  name 'Monsieur La Doulaise'
+  homepage 'http://www.google.com/fonts/specimen/Monsieur+La+Doulaise'
+
+  font 'MonsieurLaDoulaise-Regular.ttf'
+end

--- a/Casks/font-montaga.rb
+++ b/Casks/font-montaga.rb
@@ -1,0 +1,11 @@
+cask 'font-montaga' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/montaga/Montaga-Regular.ttf'
+  name 'Montaga'
+  homepage 'http://www.google.com/fonts/specimen/Montaga'
+
+  font 'Montaga-Regular.ttf'
+end

--- a/Casks/font-montez.rb
+++ b/Casks/font-montez.rb
@@ -1,0 +1,11 @@
+cask 'font-montez' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/montez/Montez-Regular.ttf'
+  name 'Montez'
+  homepage 'http://www.google.com/fonts/specimen/Montez'
+
+  font 'Montez-Regular.ttf'
+end

--- a/Casks/font-moul.rb
+++ b/Casks/font-moul.rb
@@ -1,0 +1,11 @@
+cask 'font-moul' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/moul/Moul.ttf'
+  name 'Moul'
+  homepage 'http://www.google.com/fonts/specimen/Moul'
+
+  font 'Moul.ttf'
+end

--- a/Casks/font-mouse-memoirs.rb
+++ b/Casks/font-mouse-memoirs.rb
@@ -1,0 +1,11 @@
+cask 'font-mouse-memoirs' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/mousememoirs/MouseMemoirs-Regular.ttf'
+  name 'Mouse Memoirs'
+  homepage 'http://www.google.com/fonts/specimen/Mouse+Memoirs'
+
+  font 'MouseMemoirs-Regular.ttf'
+end

--- a/Casks/font-mr-bedfort.rb
+++ b/Casks/font-mr-bedfort.rb
@@ -1,0 +1,11 @@
+cask 'font-mr-bedfort' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/mrbedfort/MrBedfort-Regular.ttf'
+  name 'Mr Bedfort'
+  homepage 'http://www.google.com/fonts/specimen/Mr+Bedfort'
+
+  font 'MrBedfort-Regular.ttf'
+end

--- a/Casks/font-mr-dafoe.rb
+++ b/Casks/font-mr-dafoe.rb
@@ -1,0 +1,11 @@
+cask 'font-mr-dafoe' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/mrdafoe/MrDafoe-Regular.ttf'
+  name 'Mr Dafoe'
+  homepage 'http://www.google.com/fonts/specimen/Mr+Dafoe'
+
+  font 'MrDafoe-Regular.ttf'
+end

--- a/Casks/font-mr-de-haviland.rb
+++ b/Casks/font-mr-de-haviland.rb
@@ -1,0 +1,11 @@
+cask 'font-mr-de-haviland' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/mrdehaviland/MrDeHaviland-Regular.ttf'
+  name 'Mr De Haviland'
+  homepage 'http://www.google.com/fonts/specimen/Mr+De+Haviland'
+
+  font 'MrDeHaviland-Regular.ttf'
+end

--- a/Casks/font-mrs-saint-delafield.rb
+++ b/Casks/font-mrs-saint-delafield.rb
@@ -1,0 +1,11 @@
+cask 'font-mrs-saint-delafield' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/mrssaintdelafield/MrsSaintDelafield-Regular.ttf'
+  name 'Mrs Saint Delafield'
+  homepage 'http://www.google.com/fonts/specimen/Mrs+Saint+Delafield'
+
+  font 'MrsSaintDelafield-Regular.ttf'
+end

--- a/Casks/font-mrs-sheppards.rb
+++ b/Casks/font-mrs-sheppards.rb
@@ -1,0 +1,11 @@
+cask 'font-mrs-sheppards' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/mrssheppards/MrsSheppards-Regular.ttf'
+  name 'Mrs Sheppards'
+  homepage 'http://www.google.com/fonts/specimen/Mrs+Sheppards'
+
+  font 'MrsSheppards-Regular.ttf'
+end

--- a/Casks/font-mystery-quest.rb
+++ b/Casks/font-mystery-quest.rb
@@ -1,0 +1,11 @@
+cask 'font-mystery-quest' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/mysteryquest/MysteryQuest-Regular.ttf'
+  name 'Mystery Quest'
+  homepage 'http://www.google.com/fonts/specimen/Mystery+Quest'
+
+  font 'MysteryQuest-Regular.ttf'
+end

--- a/Casks/font-neucha.rb
+++ b/Casks/font-neucha.rb
@@ -1,0 +1,11 @@
+cask 'font-neucha' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/neucha/Neucha.ttf'
+  name 'Neucha'
+  homepage 'http://www.google.com/fonts/specimen/Neucha'
+
+  font 'Neucha.ttf'
+end

--- a/Casks/font-new-rocker.rb
+++ b/Casks/font-new-rocker.rb
@@ -1,0 +1,11 @@
+cask 'font-new-rocker' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/newrocker/NewRocker-Regular.ttf'
+  name 'New Rocker'
+  homepage 'http://www.google.com/fonts/specimen/New+Rocker'
+
+  font 'NewRocker-Regular.ttf'
+end

--- a/Casks/font-niconne.rb
+++ b/Casks/font-niconne.rb
@@ -1,0 +1,11 @@
+cask 'font-niconne' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/niconne/Niconne-Regular.ttf'
+  name 'Niconne'
+  homepage 'http://www.google.com/fonts/specimen/Niconne'
+
+  font 'Niconne-Regular.ttf'
+end

--- a/Casks/font-nixie-one.rb
+++ b/Casks/font-nixie-one.rb
@@ -1,0 +1,11 @@
+cask 'font-nixie-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/nixieone/NixieOne-Regular.ttf'
+  name 'Nixie One'
+  homepage 'http://www.google.com/fonts/specimen/Nixie+One'
+
+  font 'NixieOne-Regular.ttf'
+end

--- a/Casks/font-norican.rb
+++ b/Casks/font-norican.rb
@@ -1,0 +1,11 @@
+cask 'font-norican' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/norican/Norican-Regular.ttf'
+  name 'Norican'
+  homepage 'http://www.google.com/fonts/specimen/Norican'
+
+  font 'Norican-Regular.ttf'
+end

--- a/Casks/font-nosifer.rb
+++ b/Casks/font-nosifer.rb
@@ -1,0 +1,11 @@
+cask 'font-nosifer' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/nosifer/Nosifer-Regular.ttf'
+  name 'Nosifer'
+  homepage 'http://www.google.com/fonts/specimen/Nosifer'
+
+  font 'Nosifer-Regular.ttf'
+end

--- a/Casks/font-nothing-you-could-do.rb
+++ b/Casks/font-nothing-you-could-do.rb
@@ -1,0 +1,11 @@
+cask 'font-nothing-you-could-do' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/nothingyoucoulddo/NothingYouCouldDo.ttf'
+  name 'Nothing You Could Do'
+  homepage 'http://www.google.com/fonts/specimen/Nothing+You+Could+Do'
+
+  font 'NothingYouCouldDo.ttf'
+end

--- a/Casks/font-numans.rb
+++ b/Casks/font-numans.rb
@@ -1,0 +1,11 @@
+cask 'font-numans' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/numans/Numans-Regular.ttf'
+  name 'Numans'
+  homepage 'http://www.google.com/fonts/specimen/Numans'
+
+  font 'Numans-Regular.ttf'
+end

--- a/Casks/font-offside.rb
+++ b/Casks/font-offside.rb
@@ -1,0 +1,11 @@
+cask 'font-offside' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/offside/Offside-Regular.ttf'
+  name 'Offside'
+  homepage 'http://www.google.com/fonts/specimen/Offside'
+
+  font 'Offside-Regular.ttf'
+end

--- a/Casks/font-oldenburg.rb
+++ b/Casks/font-oldenburg.rb
@@ -1,0 +1,11 @@
+cask 'font-oldenburg' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/oldenburg/Oldenburg-Regular.ttf'
+  name 'Oldenburg'
+  homepage 'http://www.google.com/fonts/specimen/Oldenburg'
+
+  font 'Oldenburg-Regular.ttf'
+end

--- a/Casks/font-oranienbaum.rb
+++ b/Casks/font-oranienbaum.rb
@@ -1,0 +1,11 @@
+cask 'font-oranienbaum' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/oranienbaum/Oranienbaum-Regular.ttf'
+  name 'Oranienbaum'
+  homepage 'http://www.google.com/fonts/specimen/Oranienbaum'
+
+  font 'Oranienbaum-Regular.ttf'
+end

--- a/Casks/font-orienta.rb
+++ b/Casks/font-orienta.rb
@@ -1,0 +1,11 @@
+cask 'font-orienta' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/orienta/Orienta-Regular.ttf'
+  name 'Orienta'
+  homepage 'http://www.google.com/fonts/specimen/Orienta'
+
+  font 'Orienta-Regular.ttf'
+end

--- a/Casks/font-original-surfer.rb
+++ b/Casks/font-original-surfer.rb
@@ -1,0 +1,11 @@
+cask 'font-original-surfer' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/originalsurfer/OriginalSurfer-Regular.ttf'
+  name 'Original Surfer'
+  homepage 'http://www.google.com/fonts/specimen/Original+Surfer'
+
+  font 'OriginalSurfer-Regular.ttf'
+end

--- a/Casks/font-over-the-rainbow.rb
+++ b/Casks/font-over-the-rainbow.rb
@@ -1,0 +1,11 @@
+cask 'font-over-the-rainbow' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/overtherainbow/OvertheRainbow.ttf'
+  name 'Over the Rainbow'
+  homepage 'http://www.google.com/fonts/specimen/Over+the+Rainbow'
+
+  font 'OvertheRainbow.ttf'
+end

--- a/Casks/font-overlock-sc.rb
+++ b/Casks/font-overlock-sc.rb
@@ -1,0 +1,11 @@
+cask 'font-overlock-sc' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/overlocksc/OverlockSC-Regular.ttf'
+  name 'Overlock SC'
+  homepage 'http://www.google.com/fonts/specimen/Overlock+SC'
+
+  font 'OverlockSC-Regular.ttf'
+end

--- a/Casks/font-pacifico.rb
+++ b/Casks/font-pacifico.rb
@@ -1,0 +1,11 @@
+cask 'font-pacifico' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/pacifico/Pacifico.ttf'
+  name 'Pacifico'
+  homepage 'http://www.google.com/fonts/specimen/Pacifico'
+
+  font 'Pacifico.ttf'
+end

--- a/Casks/font-paprika.rb
+++ b/Casks/font-paprika.rb
@@ -1,0 +1,11 @@
+cask 'font-paprika' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/paprika/Paprika-Regular.ttf'
+  name 'Paprika'
+  homepage 'http://www.google.com/fonts/specimen/Paprika'
+
+  font 'Paprika-Regular.ttf'
+end

--- a/Casks/font-parisienne.rb
+++ b/Casks/font-parisienne.rb
@@ -1,0 +1,11 @@
+cask 'font-parisienne' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/parisienne/Parisienne-Regular.ttf'
+  name 'Parisienne'
+  homepage 'http://www.google.com/fonts/specimen/Parisienne'
+
+  font 'Parisienne-Regular.ttf'
+end

--- a/Casks/font-passero-one.rb
+++ b/Casks/font-passero-one.rb
@@ -1,0 +1,11 @@
+cask 'font-passero-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/passeroone/PasseroOne-Regular.ttf'
+  name 'Passero One'
+  homepage 'http://www.google.com/fonts/specimen/Passero+One'
+
+  font 'PasseroOne-Regular.ttf'
+end

--- a/Casks/font-pathway-gothic-one.rb
+++ b/Casks/font-pathway-gothic-one.rb
@@ -1,0 +1,11 @@
+cask 'font-pathway-gothic-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/pathwaygothicone/PathwayGothicOne-Regular.ttf'
+  name 'Pathway Gothic One'
+  homepage 'http://www.google.com/fonts/specimen/Pathway+Gothic+One'
+
+  font 'PathwayGothicOne-Regular.ttf'
+end

--- a/Casks/font-patrick-hand-sc.rb
+++ b/Casks/font-patrick-hand-sc.rb
@@ -1,0 +1,11 @@
+cask 'font-patrick-hand-sc' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/patrickhandsc/PatrickHandSC-Regular.ttf'
+  name 'Patrick Hand SC'
+  homepage 'http://www.google.com/fonts/specimen/Patrick+Hand+SC'
+
+  font 'PatrickHandSC-Regular.ttf'
+end

--- a/Casks/font-patrick-hand.rb
+++ b/Casks/font-patrick-hand.rb
@@ -1,0 +1,11 @@
+cask 'font-patrick-hand' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/patrickhand/PatrickHand-Regular.ttf'
+  name 'Patrick Hand'
+  homepage 'http://www.google.com/fonts/specimen/Patrick+Hand'
+
+  font 'PatrickHand-Regular.ttf'
+end

--- a/Casks/font-patua-one.rb
+++ b/Casks/font-patua-one.rb
@@ -1,0 +1,11 @@
+cask 'font-patua-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/patuaone/PatuaOne-Regular.ttf'
+  name 'Patua One'
+  homepage 'http://www.google.com/fonts/specimen/Patua+One'
+
+  font 'PatuaOne-Regular.ttf'
+end

--- a/Casks/font-paytone-one.rb
+++ b/Casks/font-paytone-one.rb
@@ -1,0 +1,11 @@
+cask 'font-paytone-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/paytoneone/PaytoneOne.ttf'
+  name 'Paytone One'
+  homepage 'http://www.google.com/fonts/specimen/Paytone+One'
+
+  font 'PaytoneOne.ttf'
+end

--- a/Casks/font-peralta.rb
+++ b/Casks/font-peralta.rb
@@ -1,0 +1,11 @@
+cask 'font-peralta' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/peralta/Peralta-Regular.ttf'
+  name 'Peralta'
+  homepage 'http://www.google.com/fonts/specimen/Peralta'
+
+  font 'Peralta-Regular.ttf'
+end

--- a/Casks/font-permanent-marker.rb
+++ b/Casks/font-permanent-marker.rb
@@ -1,0 +1,11 @@
+cask 'font-permanent-marker' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/permanentmarker/PermanentMarker.ttf'
+  name 'Permanent Marker'
+  homepage 'http://www.google.com/fonts/specimen/Permanent+Marker'
+
+  font 'PermanentMarker.ttf'
+end

--- a/Casks/font-petit-formal-script.rb
+++ b/Casks/font-petit-formal-script.rb
@@ -1,0 +1,11 @@
+cask 'font-petit-formal-script' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/petitformalscript/PetitFormalScript-Regular.ttf'
+  name 'Petit Formal Script'
+  homepage 'http://www.google.com/fonts/specimen/Petit+Formal+Script'
+
+  font 'PetitFormalScript-Regular.ttf'
+end

--- a/Casks/font-petrona.rb
+++ b/Casks/font-petrona.rb
@@ -1,0 +1,11 @@
+cask 'font-petrona' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/petrona/Petrona-Regular.ttf'
+  name 'Petrona'
+  homepage 'http://www.google.com/fonts/specimen/Petrona'
+
+  font 'Petrona-Regular.ttf'
+end

--- a/Casks/font-piedra.rb
+++ b/Casks/font-piedra.rb
@@ -1,0 +1,11 @@
+cask 'font-piedra' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/piedra/Piedra-Regular.ttf'
+  name 'Piedra'
+  homepage 'http://www.google.com/fonts/specimen/Piedra'
+
+  font 'Piedra-Regular.ttf'
+end

--- a/Casks/font-pinyon-script.rb
+++ b/Casks/font-pinyon-script.rb
@@ -1,0 +1,11 @@
+cask 'font-pinyon-script' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/pinyonscript/PinyonScript-Regular.ttf'
+  name 'Pinyon Script'
+  homepage 'http://www.google.com/fonts/specimen/Pinyon+Script'
+
+  font 'PinyonScript-Regular.ttf'
+end

--- a/Casks/font-pirata-one.rb
+++ b/Casks/font-pirata-one.rb
@@ -1,0 +1,11 @@
+cask 'font-pirata-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/pirataone/PirataOne-Regular.ttf'
+  name 'Pirata One'
+  homepage 'http://www.google.com/fonts/specimen/Pirata+One'
+
+  font 'PirataOne-Regular.ttf'
+end

--- a/Casks/font-plaster.rb
+++ b/Casks/font-plaster.rb
@@ -1,0 +1,11 @@
+cask 'font-plaster' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/plaster/Plaster-Regular.ttf'
+  name 'Plaster'
+  homepage 'http://www.google.com/fonts/specimen/Plaster'
+
+  font 'Plaster-Regular.ttf'
+end

--- a/Casks/font-playball.rb
+++ b/Casks/font-playball.rb
@@ -1,0 +1,11 @@
+cask 'font-playball' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/playball/Playball-Regular.ttf'
+  name 'Playball'
+  homepage 'http://www.google.com/fonts/specimen/Playball'
+
+  font 'Playball-Regular.ttf'
+end

--- a/Casks/font-poiret-one.rb
+++ b/Casks/font-poiret-one.rb
@@ -1,0 +1,11 @@
+cask 'font-poiret-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/poiretone/PoiretOne-Regular.ttf'
+  name 'Poiret One'
+  homepage 'http://www.google.com/fonts/specimen/Poiret+One'
+
+  font 'PoiretOne-Regular.ttf'
+end

--- a/Casks/font-poller-one.rb
+++ b/Casks/font-poller-one.rb
@@ -1,0 +1,11 @@
+cask 'font-poller-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/pollerone/PollerOne.ttf'
+  name 'Poller One'
+  homepage 'http://www.google.com/fonts/specimen/Poller+One'
+
+  font 'PollerOne.ttf'
+end

--- a/Casks/font-pompiere.rb
+++ b/Casks/font-pompiere.rb
@@ -1,0 +1,11 @@
+cask 'font-pompiere' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/pompiere/Pompiere-Regular.ttf'
+  name 'Pompiere'
+  homepage 'http://www.google.com/fonts/specimen/Pompiere'
+
+  font 'Pompiere-Regular.ttf'
+end

--- a/Casks/font-pontano-sans.rb
+++ b/Casks/font-pontano-sans.rb
@@ -1,0 +1,11 @@
+cask 'font-pontano-sans' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/pontanosans/PontanoSans-Regular.ttf'
+  name 'Pontano Sans'
+  homepage 'http://www.google.com/fonts/specimen/Pontano+Sans'
+
+  font 'PontanoSans-Regular.ttf'
+end

--- a/Casks/font-port-lligat-sans.rb
+++ b/Casks/font-port-lligat-sans.rb
@@ -1,0 +1,11 @@
+cask 'font-port-lligat-sans' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/portlligatsans/PortLligatSans-Regular.ttf'
+  name 'Port Lligat Sans'
+  homepage 'http://www.google.com/fonts/specimen/Port+Lligat+Sans'
+
+  font 'PortLligatSans-Regular.ttf'
+end

--- a/Casks/font-port-lligat-slab.rb
+++ b/Casks/font-port-lligat-slab.rb
@@ -1,0 +1,11 @@
+cask 'font-port-lligat-slab' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/portlligatslab/PortLligatSlab-Regular.ttf'
+  name 'Port Lligat Slab'
+  homepage 'http://www.google.com/fonts/specimen/Port+Lligat+Slab'
+
+  font 'PortLligatSlab-Regular.ttf'
+end

--- a/Casks/font-prata.rb
+++ b/Casks/font-prata.rb
@@ -1,0 +1,11 @@
+cask 'font-prata' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/prata/Prata-Regular.ttf'
+  name 'Prata'
+  homepage 'http://www.google.com/fonts/specimen/Prata'
+
+  font 'Prata-Regular.ttf'
+end

--- a/Casks/font-princess-sofia.rb
+++ b/Casks/font-princess-sofia.rb
@@ -1,0 +1,11 @@
+cask 'font-princess-sofia' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/princesssofia/PrincessSofia-Regular.ttf'
+  name 'Princess Sofia'
+  homepage 'http://www.google.com/fonts/specimen/Princess+Sofia'
+
+  font 'PrincessSofia-Regular.ttf'
+end

--- a/Casks/font-prociono.rb
+++ b/Casks/font-prociono.rb
@@ -1,0 +1,11 @@
+cask 'font-prociono' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/prociono/Prociono-Regular.ttf'
+  name 'Prociono'
+  homepage 'http://www.google.com/fonts/specimen/Prociono'
+
+  font 'Prociono-Regular.ttf'
+end

--- a/Casks/font-prosto-one.rb
+++ b/Casks/font-prosto-one.rb
@@ -1,0 +1,11 @@
+cask 'font-prosto-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/prostoone/ProstoOne-Regular.ttf'
+  name 'Prosto One'
+  homepage 'http://www.google.com/fonts/specimen/Prosto+One'
+
+  font 'ProstoOne-Regular.ttf'
+end

--- a/Casks/font-purple-purse.rb
+++ b/Casks/font-purple-purse.rb
@@ -1,0 +1,11 @@
+cask 'font-purple-purse' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/purplepurse/PurplePurse-Regular.ttf'
+  name 'Purple Purse'
+  homepage 'http://www.google.com/fonts/specimen/Purple+Purse'
+
+  font 'PurplePurse-Regular.ttf'
+end

--- a/Casks/font-quando.rb
+++ b/Casks/font-quando.rb
@@ -1,0 +1,11 @@
+cask 'font-quando' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/quando/Quando-Regular.ttf'
+  name 'Quando'
+  homepage 'http://www.google.com/fonts/specimen/Quando'
+
+  font 'Quando-Regular.ttf'
+end

--- a/Casks/font-quintessential.rb
+++ b/Casks/font-quintessential.rb
@@ -1,0 +1,11 @@
+cask 'font-quintessential' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/quintessential/Quintessential-Regular.ttf'
+  name 'Quintessential'
+  homepage 'http://www.google.com/fonts/specimen/Quintessential'
+
+  font 'Quintessential-Regular.ttf'
+end

--- a/Casks/font-qwigley.rb
+++ b/Casks/font-qwigley.rb
@@ -1,0 +1,11 @@
+cask 'font-qwigley' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/qwigley/Qwigley-Regular.ttf'
+  name 'Qwigley'
+  homepage 'http://www.google.com/fonts/specimen/Qwigley'
+
+  font 'Qwigley-Regular.ttf'
+end

--- a/Casks/font-racing-sans-one.rb
+++ b/Casks/font-racing-sans-one.rb
@@ -1,0 +1,11 @@
+cask 'font-racing-sans-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/racingsansone/RacingSansOne-Regular.ttf'
+  name 'Racing Sans One'
+  homepage 'http://www.google.com/fonts/specimen/Racing+Sans+One'
+
+  font 'RacingSansOne-Regular.ttf'
+end

--- a/Casks/font-raleway-dots.rb
+++ b/Casks/font-raleway-dots.rb
@@ -1,0 +1,11 @@
+cask 'font-raleway-dots' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/ralewaydots/RalewayDots-Regular.ttf'
+  name 'Raleway Dots'
+  homepage 'http://www.google.com/fonts/specimen/Raleway+Dots'
+
+  font 'RalewayDots-Regular.ttf'
+end

--- a/Casks/font-rammetto-one.rb
+++ b/Casks/font-rammetto-one.rb
@@ -1,0 +1,11 @@
+cask 'font-rammetto-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/rammettoone/RammettoOne-Regular.ttf'
+  name 'Rammetto One'
+  homepage 'http://www.google.com/fonts/specimen/Rammetto+One'
+
+  font 'RammettoOne-Regular.ttf'
+end

--- a/Casks/font-ranchers.rb
+++ b/Casks/font-ranchers.rb
@@ -1,0 +1,11 @@
+cask 'font-ranchers' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/ranchers/Ranchers-Regular.ttf'
+  name 'Ranchers'
+  homepage 'http://www.google.com/fonts/specimen/Ranchers'
+
+  font 'Ranchers-Regular.ttf'
+end

--- a/Casks/font-rancho.rb
+++ b/Casks/font-rancho.rb
@@ -1,0 +1,11 @@
+cask 'font-rancho' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/rancho/Rancho-Regular.ttf'
+  name 'Rancho'
+  homepage 'http://www.google.com/fonts/specimen/Rancho'
+
+  font 'Rancho-Regular.ttf'
+end

--- a/Casks/font-rationale.rb
+++ b/Casks/font-rationale.rb
@@ -1,0 +1,11 @@
+cask 'font-rationale' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/rationale/Rationale-Regular.ttf'
+  name 'Rationale'
+  homepage 'http://www.google.com/fonts/specimen/Rationale'
+
+  font 'Rationale-Regular.ttf'
+end

--- a/Casks/font-redressed.rb
+++ b/Casks/font-redressed.rb
@@ -1,0 +1,11 @@
+cask 'font-redressed' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/redressed/Redressed.ttf'
+  name 'Redressed'
+  homepage 'http://www.google.com/fonts/specimen/Redressed'
+
+  font 'Redressed.ttf'
+end

--- a/Casks/font-reenie-beanie.rb
+++ b/Casks/font-reenie-beanie.rb
@@ -1,0 +1,11 @@
+cask 'font-reenie-beanie' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/reeniebeanie/ReenieBeanie.ttf'
+  name 'Reenie Beanie'
+  homepage 'http://www.google.com/fonts/specimen/Reenie+Beanie'
+
+  font 'ReenieBeanie.ttf'
+end

--- a/Casks/font-revalia.rb
+++ b/Casks/font-revalia.rb
@@ -1,0 +1,11 @@
+cask 'font-revalia' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/revalia/Revalia-Regular.ttf'
+  name 'Revalia'
+  homepage 'http://www.google.com/fonts/specimen/Revalia'
+
+  font 'Revalia-Regular.ttf'
+end

--- a/Casks/font-ribeye-marrow.rb
+++ b/Casks/font-ribeye-marrow.rb
@@ -1,0 +1,11 @@
+cask 'font-ribeye-marrow' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/ribeyemarrow/RibeyeMarrow-Regular.ttf'
+  name 'Ribeye Marrow'
+  homepage 'http://www.google.com/fonts/specimen/Ribeye+Marrow'
+
+  font 'RibeyeMarrow-Regular.ttf'
+end

--- a/Casks/font-ribeye.rb
+++ b/Casks/font-ribeye.rb
@@ -1,0 +1,11 @@
+cask 'font-ribeye' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/ribeye/Ribeye-Regular.ttf'
+  name 'Ribeye'
+  homepage 'http://www.google.com/fonts/specimen/Ribeye'
+
+  font 'Ribeye-Regular.ttf'
+end

--- a/Casks/font-righteous.rb
+++ b/Casks/font-righteous.rb
@@ -1,0 +1,11 @@
+cask 'font-righteous' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/righteous/Righteous-Regular.ttf'
+  name 'Righteous'
+  homepage 'http://www.google.com/fonts/specimen/Righteous'
+
+  font 'Righteous-Regular.ttf'
+end

--- a/Casks/font-risque.rb
+++ b/Casks/font-risque.rb
@@ -1,0 +1,11 @@
+cask 'font-risque' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/risque/Risque-Regular.ttf'
+  name 'Risque'
+  homepage 'http://www.google.com/fonts/specimen/Risque'
+
+  font 'Risque-Regular.ttf'
+end

--- a/Casks/font-rochester.rb
+++ b/Casks/font-rochester.rb
@@ -1,0 +1,11 @@
+cask 'font-rochester' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/rochester/Rochester-Regular.ttf'
+  name 'Rochester'
+  homepage 'http://www.google.com/fonts/specimen/Rochester'
+
+  font 'Rochester-Regular.ttf'
+end

--- a/Casks/font-rock-salt.rb
+++ b/Casks/font-rock-salt.rb
@@ -1,0 +1,11 @@
+cask 'font-rock-salt' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/rocksalt/RockSalt.ttf'
+  name 'Rock Salt'
+  homepage 'http://www.google.com/fonts/specimen/Rock+Salt'
+
+  font 'RockSalt.ttf'
+end

--- a/Casks/font-romanesco.rb
+++ b/Casks/font-romanesco.rb
@@ -1,0 +1,11 @@
+cask 'font-romanesco' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/romanesco/Romanesco-Regular.ttf'
+  name 'Romanesco'
+  homepage 'http://www.google.com/fonts/specimen/Romanesco'
+
+  font 'Romanesco-Regular.ttf'
+end

--- a/Casks/font-rouge-script.rb
+++ b/Casks/font-rouge-script.rb
@@ -1,0 +1,11 @@
+cask 'font-rouge-script' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/rougescript/RougeScript-Regular.ttf'
+  name 'Rouge Script'
+  homepage 'http://www.google.com/fonts/specimen/Rouge+Script'
+
+  font 'RougeScript-Regular.ttf'
+end

--- a/Casks/font-ruge-boogie.rb
+++ b/Casks/font-ruge-boogie.rb
@@ -1,0 +1,11 @@
+cask 'font-ruge-boogie' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/rugeboogie/RugeBoogie-Regular.ttf'
+  name 'Ruge Boogie'
+  homepage 'http://www.google.com/fonts/specimen/Ruge+Boogie'
+
+  font 'RugeBoogie-Regular.ttf'
+end

--- a/Casks/font-ruluko.rb
+++ b/Casks/font-ruluko.rb
@@ -1,0 +1,11 @@
+cask 'font-ruluko' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/ruluko/Ruluko-Regular.ttf'
+  name 'Ruluko'
+  homepage 'http://www.google.com/fonts/specimen/Ruluko'
+
+  font 'Ruluko-Regular.ttf'
+end

--- a/Casks/font-rum-raisin.rb
+++ b/Casks/font-rum-raisin.rb
@@ -1,0 +1,11 @@
+cask 'font-rum-raisin' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/rumraisin/RumRaisin-Regular.ttf'
+  name 'Rum Raisin'
+  homepage 'http://www.google.com/fonts/specimen/Rum+Raisin'
+
+  font 'RumRaisin-Regular.ttf'
+end

--- a/Casks/font-ruslan-display.rb
+++ b/Casks/font-ruslan-display.rb
@@ -1,0 +1,11 @@
+cask 'font-ruslan-display' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/ruslandisplay/RuslanDisplay.ttf'
+  name 'Ruslan Display'
+  homepage 'http://www.google.com/fonts/specimen/Ruslan+Display'
+
+  font 'RuslanDisplay.ttf'
+end

--- a/Casks/font-russo-one.rb
+++ b/Casks/font-russo-one.rb
@@ -1,0 +1,11 @@
+cask 'font-russo-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/russoone/RussoOne-Regular.ttf'
+  name 'Russo One'
+  homepage 'http://www.google.com/fonts/specimen/Russo+One'
+
+  font 'RussoOne-Regular.ttf'
+end

--- a/Casks/font-ruthie.rb
+++ b/Casks/font-ruthie.rb
@@ -1,0 +1,11 @@
+cask 'font-ruthie' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/ruthie/Ruthie-Regular.ttf'
+  name 'Ruthie'
+  homepage 'http://www.google.com/fonts/specimen/Ruthie'
+
+  font 'Ruthie-Regular.ttf'
+end

--- a/Casks/font-rye.rb
+++ b/Casks/font-rye.rb
@@ -1,0 +1,11 @@
+cask 'font-rye' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/rye/Rye-Regular.ttf'
+  name 'Rye'
+  homepage 'http://www.google.com/fonts/specimen/Rye'
+
+  font 'Rye-Regular.ttf'
+end

--- a/Casks/font-sacramento.rb
+++ b/Casks/font-sacramento.rb
@@ -1,0 +1,11 @@
+cask 'font-sacramento' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/sacramento/Sacramento-Regular.ttf'
+  name 'Sacramento'
+  homepage 'http://www.google.com/fonts/specimen/Sacramento'
+
+  font 'Sacramento-Regular.ttf'
+end

--- a/Casks/font-sail.rb
+++ b/Casks/font-sail.rb
@@ -1,0 +1,11 @@
+cask 'font-sail' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/sail/Sail-Regular.ttf'
+  name 'Sail'
+  homepage 'http://www.google.com/fonts/specimen/Sail'
+
+  font 'Sail-Regular.ttf'
+end

--- a/Casks/font-salsa.rb
+++ b/Casks/font-salsa.rb
@@ -1,0 +1,11 @@
+cask 'font-salsa' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/salsa/Salsa-Regular.ttf'
+  name 'Salsa'
+  homepage 'http://www.google.com/fonts/specimen/Salsa'
+
+  font 'Salsa-Regular.ttf'
+end

--- a/Casks/font-sancreek.rb
+++ b/Casks/font-sancreek.rb
@@ -1,0 +1,11 @@
+cask 'font-sancreek' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/sancreek/Sancreek-Regular.ttf'
+  name 'Sancreek'
+  homepage 'http://www.google.com/fonts/specimen/Sancreek'
+
+  font 'Sancreek-Regular.ttf'
+end

--- a/Casks/font-sansita-one.rb
+++ b/Casks/font-sansita-one.rb
@@ -1,0 +1,11 @@
+cask 'font-sansita-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/sansitaone/SansitaOne.ttf'
+  name 'Sansita One'
+  homepage 'http://www.google.com/fonts/specimen/Sansita+One'
+
+  font 'SansitaOne.ttf'
+end

--- a/Casks/font-sarina.rb
+++ b/Casks/font-sarina.rb
@@ -1,0 +1,11 @@
+cask 'font-sarina' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/sarina/Sarina-Regular.ttf'
+  name 'Sarina'
+  homepage 'http://www.google.com/fonts/specimen/Sarina'
+
+  font 'Sarina-Regular.ttf'
+end

--- a/Casks/font-satisfy.rb
+++ b/Casks/font-satisfy.rb
@@ -1,0 +1,11 @@
+cask 'font-satisfy' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/satisfy/Satisfy-Regular.ttf'
+  name 'Satisfy'
+  homepage 'http://www.google.com/fonts/specimen/Satisfy'
+
+  font 'Satisfy-Regular.ttf'
+end

--- a/Casks/font-schoolbell.rb
+++ b/Casks/font-schoolbell.rb
@@ -1,0 +1,11 @@
+cask 'font-schoolbell' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/schoolbell/Schoolbell.ttf'
+  name 'Schoolbell'
+  homepage 'http://www.google.com/fonts/specimen/Schoolbell'
+
+  font 'Schoolbell.ttf'
+end

--- a/Casks/font-seaweed-script.rb
+++ b/Casks/font-seaweed-script.rb
@@ -1,0 +1,11 @@
+cask 'font-seaweed-script' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/seaweedscript/SeaweedScript-Regular.ttf'
+  name 'Seaweed Script'
+  homepage 'http://www.google.com/fonts/specimen/Seaweed+Script'
+
+  font 'SeaweedScript-Regular.ttf'
+end

--- a/Casks/font-sevillana.rb
+++ b/Casks/font-sevillana.rb
@@ -1,0 +1,11 @@
+cask 'font-sevillana' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/sevillana/Sevillana-Regular.ttf'
+  name 'Sevillana'
+  homepage 'http://www.google.com/fonts/specimen/Sevillana'
+
+  font 'Sevillana-Regular.ttf'
+end

--- a/Casks/font-seymour-one.rb
+++ b/Casks/font-seymour-one.rb
@@ -1,0 +1,11 @@
+cask 'font-seymour-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/seymourone/SeymourOne-Regular.ttf'
+  name 'Seymour One'
+  homepage 'http://www.google.com/fonts/specimen/Seymour+One'
+
+  font 'SeymourOne-Regular.ttf'
+end

--- a/Casks/font-shadows-into-light-two.rb
+++ b/Casks/font-shadows-into-light-two.rb
@@ -1,0 +1,11 @@
+cask 'font-shadows-into-light-two' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/shadowsintolighttwo/ShadowsIntoLightTwo-Regular.ttf'
+  name 'Shadows Into Light Two'
+  homepage 'http://www.google.com/fonts/specimen/Shadows+Into+Light+Two'
+
+  font 'ShadowsIntoLightTwo-Regular.ttf'
+end

--- a/Casks/font-shadows-into-light.rb
+++ b/Casks/font-shadows-into-light.rb
@@ -1,0 +1,11 @@
+cask 'font-shadows-into-light' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/shadowsintolight/ShadowsIntoLight.ttf'
+  name 'Shadows Into Light'
+  homepage 'http://www.google.com/fonts/specimen/Shadows+Into+Light'
+
+  font 'ShadowsIntoLight.ttf'
+end

--- a/Casks/font-shanti.rb
+++ b/Casks/font-shanti.rb
@@ -1,0 +1,11 @@
+cask 'font-shanti' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/shanti/Shanti-Regular.ttf'
+  name 'Shanti'
+  homepage 'http://www.google.com/fonts/specimen/Shanti'
+
+  font 'Shanti-Regular.ttf'
+end

--- a/Casks/font-shojumaru.rb
+++ b/Casks/font-shojumaru.rb
@@ -1,0 +1,11 @@
+cask 'font-shojumaru' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/shojumaru/Shojumaru-Regular.ttf'
+  name 'Shojumaru'
+  homepage 'http://www.google.com/fonts/specimen/Shojumaru'
+
+  font 'Shojumaru-Regular.ttf'
+end

--- a/Casks/font-short-stack.rb
+++ b/Casks/font-short-stack.rb
@@ -1,0 +1,11 @@
+cask 'font-short-stack' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/shortstack/ShortStack-Regular.ttf'
+  name 'Short Stack'
+  homepage 'http://www.google.com/fonts/specimen/Short+Stack'
+
+  font 'ShortStack-Regular.ttf'
+end

--- a/Casks/font-siemreap.rb
+++ b/Casks/font-siemreap.rb
@@ -1,0 +1,11 @@
+cask 'font-siemreap' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/siemreap/Siemreap.ttf'
+  name 'Siemreap'
+  homepage 'http://www.google.com/fonts/specimen/Siemreap'
+
+  font 'Siemreap.ttf'
+end

--- a/Casks/font-sigmar-one.rb
+++ b/Casks/font-sigmar-one.rb
@@ -1,0 +1,11 @@
+cask 'font-sigmar-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/sigmarone/SigmarOne.ttf'
+  name 'Sigmar One'
+  homepage 'http://www.google.com/fonts/specimen/Sigmar+One'
+
+  font 'SigmarOne.ttf'
+end

--- a/Casks/font-six-caps.rb
+++ b/Casks/font-six-caps.rb
@@ -1,0 +1,11 @@
+cask 'font-six-caps' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/sixcaps/SixCaps.ttf'
+  name 'Six Caps'
+  homepage 'http://www.google.com/fonts/specimen/Six+Caps'
+
+  font 'SixCaps.ttf'
+end

--- a/Casks/font-slackey.rb
+++ b/Casks/font-slackey.rb
@@ -1,0 +1,11 @@
+cask 'font-slackey' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/slackey/Slackey.ttf'
+  name 'Slackey'
+  homepage 'http://www.google.com/fonts/specimen/Slackey'
+
+  font 'Slackey.ttf'
+end

--- a/Casks/font-smokum.rb
+++ b/Casks/font-smokum.rb
@@ -1,0 +1,11 @@
+cask 'font-smokum' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/smokum/Smokum-Regular.ttf'
+  name 'Smokum'
+  homepage 'http://www.google.com/fonts/specimen/Smokum'
+
+  font 'Smokum-Regular.ttf'
+end

--- a/Casks/font-smythe.rb
+++ b/Casks/font-smythe.rb
@@ -1,0 +1,11 @@
+cask 'font-smythe' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/smythe/Smythe-Regular.ttf'
+  name 'Smythe'
+  homepage 'http://www.google.com/fonts/specimen/Smythe'
+
+  font 'Smythe-Regular.ttf'
+end

--- a/Casks/font-snippet.rb
+++ b/Casks/font-snippet.rb
@@ -1,0 +1,11 @@
+cask 'font-snippet' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/snippet/Snippet.ttf'
+  name 'Snippet'
+  homepage 'http://www.google.com/fonts/specimen/Snippet'
+
+  font 'Snippet.ttf'
+end

--- a/Casks/font-snowburst-one.rb
+++ b/Casks/font-snowburst-one.rb
@@ -1,0 +1,11 @@
+cask 'font-snowburst-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/snowburstone/SnowburstOne-Regular.ttf'
+  name 'Snowburst One'
+  homepage 'http://www.google.com/fonts/specimen/Snowburst+One'
+
+  font 'SnowburstOne-Regular.ttf'
+end

--- a/Casks/font-sofadi-one.rb
+++ b/Casks/font-sofadi-one.rb
@@ -1,0 +1,11 @@
+cask 'font-sofadi-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/sofadione/SofadiOne-Regular.ttf'
+  name 'Sofadi One'
+  homepage 'http://www.google.com/fonts/specimen/Sofadi+One'
+
+  font 'SofadiOne-Regular.ttf'
+end

--- a/Casks/font-sofia.rb
+++ b/Casks/font-sofia.rb
@@ -1,0 +1,11 @@
+cask 'font-sofia' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/sofia/Sofia-Regular.ttf'
+  name 'Sofia'
+  homepage 'http://www.google.com/fonts/specimen/Sofia'
+
+  font 'Sofia-Regular.ttf'
+end

--- a/Casks/font-sonsie-one.rb
+++ b/Casks/font-sonsie-one.rb
@@ -1,0 +1,11 @@
+cask 'font-sonsie-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/sonsieone/SonsieOne-Regular.ttf'
+  name 'Sonsie One'
+  homepage 'http://www.google.com/fonts/specimen/Sonsie+One'
+
+  font 'SonsieOne-Regular.ttf'
+end

--- a/Casks/font-special-elite.rb
+++ b/Casks/font-special-elite.rb
@@ -1,0 +1,11 @@
+cask 'font-special-elite' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/specialelite/SpecialElite.ttf'
+  name 'Special Elite'
+  homepage 'http://www.google.com/fonts/specimen/Special+Elite'
+
+  font 'SpecialElite.ttf'
+end

--- a/Casks/font-spicy-rice.rb
+++ b/Casks/font-spicy-rice.rb
@@ -1,0 +1,11 @@
+cask 'font-spicy-rice' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/spicyrice/SpicyRice-Regular.ttf'
+  name 'Spicy Rice'
+  homepage 'http://www.google.com/fonts/specimen/Spicy+Rice'
+
+  font 'SpicyRice-Regular.ttf'
+end

--- a/Casks/font-spinnaker.rb
+++ b/Casks/font-spinnaker.rb
@@ -1,0 +1,11 @@
+cask 'font-spinnaker' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/spinnaker/Spinnaker-Regular.ttf'
+  name 'Spinnaker'
+  homepage 'http://www.google.com/fonts/specimen/Spinnaker'
+
+  font 'Spinnaker-Regular.ttf'
+end

--- a/Casks/font-spirax.rb
+++ b/Casks/font-spirax.rb
@@ -1,0 +1,11 @@
+cask 'font-spirax' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/spirax/Spirax-Regular.ttf'
+  name 'Spirax'
+  homepage 'http://www.google.com/fonts/specimen/Spirax'
+
+  font 'Spirax-Regular.ttf'
+end

--- a/Casks/font-squada-one.rb
+++ b/Casks/font-squada-one.rb
@@ -1,0 +1,11 @@
+cask 'font-squada-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/squadaone/SquadaOne-Regular.ttf'
+  name 'Squada One'
+  homepage 'http://www.google.com/fonts/specimen/Squada+One'
+
+  font 'SquadaOne-Regular.ttf'
+end

--- a/Casks/font-stalemate.rb
+++ b/Casks/font-stalemate.rb
@@ -1,0 +1,11 @@
+cask 'font-stalemate' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/stalemate/Stalemate-Regular.ttf'
+  name 'Stalemate'
+  homepage 'http://www.google.com/fonts/specimen/Stalemate'
+
+  font 'Stalemate-Regular.ttf'
+end

--- a/Casks/font-stalinist-one.rb
+++ b/Casks/font-stalinist-one.rb
@@ -1,0 +1,11 @@
+cask 'font-stalinist-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/stalinistone/StalinistOne-Regular.ttf'
+  name 'Stalinist One'
+  homepage 'http://www.google.com/fonts/specimen/Stalinist+One'
+
+  font 'StalinistOne-Regular.ttf'
+end

--- a/Casks/font-stint-ultra-condensed.rb
+++ b/Casks/font-stint-ultra-condensed.rb
@@ -1,0 +1,11 @@
+cask 'font-stint-ultra-condensed' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/stintultracondensed/StintUltraCondensed-Regular.ttf'
+  name 'Stint Ultra Condensed'
+  homepage 'http://www.google.com/fonts/specimen/Stint+Ultra+Condensed'
+
+  font 'StintUltraCondensed-Regular.ttf'
+end

--- a/Casks/font-stint-ultra-expanded.rb
+++ b/Casks/font-stint-ultra-expanded.rb
@@ -1,0 +1,11 @@
+cask 'font-stint-ultra-expanded' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/stintultraexpanded/StintUltraExpanded-Regular.ttf'
+  name 'Stint Ultra Expanded'
+  homepage 'http://www.google.com/fonts/specimen/Stint+Ultra+Expanded'
+
+  font 'StintUltraExpanded-Regular.ttf'
+end

--- a/Casks/font-strait.rb
+++ b/Casks/font-strait.rb
@@ -1,0 +1,11 @@
+cask 'font-strait' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/strait/Strait-Regular.ttf'
+  name 'Strait'
+  homepage 'http://www.google.com/fonts/specimen/Strait'
+
+  font 'Strait-Regular.ttf'
+end

--- a/Casks/font-sunshiney.rb
+++ b/Casks/font-sunshiney.rb
@@ -1,0 +1,11 @@
+cask 'font-sunshiney' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/sunshiney/Sunshiney.ttf'
+  name 'Sunshiney'
+  homepage 'http://www.google.com/fonts/specimen/Sunshiney'
+
+  font 'Sunshiney.ttf'
+end

--- a/Casks/font-supermercado-one.rb
+++ b/Casks/font-supermercado-one.rb
@@ -1,0 +1,11 @@
+cask 'font-supermercado-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/supermercadoone/SupermercadoOne-Regular.ttf'
+  name 'Supermercado One'
+  homepage 'http://www.google.com/fonts/specimen/Supermercado+One'
+
+  font 'SupermercadoOne-Regular.ttf'
+end

--- a/Casks/font-swanky-and-moo-moo.rb
+++ b/Casks/font-swanky-and-moo-moo.rb
@@ -1,0 +1,11 @@
+cask 'font-swanky-and-moo-moo' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/swankyandmoomoo/SwankyandMooMoo.ttf'
+  name 'Swanky and Moo Moo'
+  homepage 'http://www.google.com/fonts/specimen/Swanky+and+Moo+Moo'
+
+  font 'SwankyandMooMoo.ttf'
+end

--- a/Casks/font-taprom.rb
+++ b/Casks/font-taprom.rb
@@ -1,0 +1,11 @@
+cask 'font-taprom' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/taprom/Taprom.ttf'
+  name 'Taprom'
+  homepage 'http://www.google.com/fonts/specimen/Taprom'
+
+  font 'Taprom.ttf'
+end

--- a/Casks/font-tauri.rb
+++ b/Casks/font-tauri.rb
@@ -1,0 +1,11 @@
+cask 'font-tauri' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/tauri/Tauri-Regular.ttf'
+  name 'Tauri'
+  homepage 'http://www.google.com/fonts/specimen/Tauri'
+
+  font 'Tauri-Regular.ttf'
+end

--- a/Casks/font-telex.rb
+++ b/Casks/font-telex.rb
@@ -1,0 +1,11 @@
+cask 'font-telex' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/telex/Telex-Regular.ttf'
+  name 'Telex'
+  homepage 'http://www.google.com/fonts/specimen/Telex'
+
+  font 'Telex-Regular.ttf'
+end

--- a/Casks/font-tenor-sans.rb
+++ b/Casks/font-tenor-sans.rb
@@ -1,0 +1,11 @@
+cask 'font-tenor-sans' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/tenorsans/TenorSans-Regular.ttf'
+  name 'Tenor Sans'
+  homepage 'http://www.google.com/fonts/specimen/Tenor+Sans'
+
+  font 'TenorSans-Regular.ttf'
+end

--- a/Casks/font-text-me-one.rb
+++ b/Casks/font-text-me-one.rb
@@ -1,0 +1,11 @@
+cask 'font-text-me-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/textmeone/TextMeOne-Regular.ttf'
+  name 'Text Me One'
+  homepage 'http://www.google.com/fonts/specimen/Text+Me+One'
+
+  font 'TextMeOne-Regular.ttf'
+end

--- a/Casks/font-the-girl-next-door.rb
+++ b/Casks/font-the-girl-next-door.rb
@@ -1,0 +1,11 @@
+cask 'font-the-girl-next-door' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/thegirlnextdoor/TheGirlNextDoor.ttf'
+  name 'The Girl Next Door'
+  homepage 'http://www.google.com/fonts/specimen/The+Girl+Next+Door'
+
+  font 'TheGirlNextDoor.ttf'
+end

--- a/Casks/font-titan-one.rb
+++ b/Casks/font-titan-one.rb
@@ -1,0 +1,11 @@
+cask 'font-titan-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/titanone/TitanOne-Regular.ttf'
+  name 'Titan One'
+  homepage 'http://www.google.com/fonts/specimen/Titan+One'
+
+  font 'TitanOne-Regular.ttf'
+end

--- a/Casks/font-trade-winds.rb
+++ b/Casks/font-trade-winds.rb
@@ -1,0 +1,11 @@
+cask 'font-trade-winds' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/tradewinds/TradeWinds-Regular.ttf'
+  name 'Trade Winds'
+  homepage 'http://www.google.com/fonts/specimen/Trade+Winds'
+
+  font 'TradeWinds-Regular.ttf'
+end

--- a/Casks/font-trocchi.rb
+++ b/Casks/font-trocchi.rb
@@ -1,0 +1,11 @@
+cask 'font-trocchi' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/trocchi/Trocchi-Regular.ttf'
+  name 'Trocchi'
+  homepage 'http://www.google.com/fonts/specimen/Trocchi'
+
+  font 'Trocchi-Regular.ttf'
+end

--- a/Casks/font-trykker.rb
+++ b/Casks/font-trykker.rb
@@ -1,0 +1,11 @@
+cask 'font-trykker' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/trykker/Trykker-Regular.ttf'
+  name 'Trykker'
+  homepage 'http://www.google.com/fonts/specimen/Trykker'
+
+  font 'Trykker-Regular.ttf'
+end

--- a/Casks/font-tulpen-one.rb
+++ b/Casks/font-tulpen-one.rb
@@ -1,0 +1,11 @@
+cask 'font-tulpen-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/tulpenone/TulpenOne-Regular.ttf'
+  name 'Tulpen One'
+  homepage 'http://www.google.com/fonts/specimen/Tulpen+One'
+
+  font 'TulpenOne-Regular.ttf'
+end

--- a/Casks/font-ultra.rb
+++ b/Casks/font-ultra.rb
@@ -1,0 +1,11 @@
+cask 'font-ultra' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/ultra/Ultra.ttf'
+  name 'Ultra'
+  homepage 'http://www.google.com/fonts/specimen/Ultra'
+
+  font 'Ultra.ttf'
+end

--- a/Casks/font-uncial-antiqua.rb
+++ b/Casks/font-uncial-antiqua.rb
@@ -1,0 +1,11 @@
+cask 'font-uncial-antiqua' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/uncialantiqua/UncialAntiqua-Regular.ttf'
+  name 'Uncial Antiqua'
+  homepage 'http://www.google.com/fonts/specimen/Uncial+Antiqua'
+
+  font 'UncialAntiqua-Regular.ttf'
+end

--- a/Casks/font-underdog.rb
+++ b/Casks/font-underdog.rb
@@ -1,0 +1,11 @@
+cask 'font-underdog' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/underdog/Underdog-Regular.ttf'
+  name 'Underdog'
+  homepage 'http://www.google.com/fonts/specimen/Underdog'
+
+  font 'Underdog-Regular.ttf'
+end

--- a/Casks/font-unica-one.rb
+++ b/Casks/font-unica-one.rb
@@ -1,0 +1,11 @@
+cask 'font-unica-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/unicaone/UnicaOne-Regular.ttf'
+  name 'Unica One'
+  homepage 'http://www.google.com/fonts/specimen/Unica+One'
+
+  font 'UnicaOne-Regular.ttf'
+end

--- a/Casks/font-unifrakturcook.rb
+++ b/Casks/font-unifrakturcook.rb
@@ -1,0 +1,11 @@
+cask 'font-unifrakturcook' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/unifrakturcook/UnifrakturCook-Bold.ttf'
+  name 'UnifrakturCook'
+  homepage 'http://www.google.com/fonts/specimen/UnifrakturCook'
+
+  font 'UnifrakturCook-Bold.ttf'
+end

--- a/Casks/font-unifrakturmaguntia.rb
+++ b/Casks/font-unifrakturmaguntia.rb
@@ -1,0 +1,11 @@
+cask 'font-unifrakturmaguntia' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/unifrakturmaguntia/UnifrakturMaguntia-Book.ttf'
+  name 'UnifrakturMaguntia'
+  homepage 'http://www.google.com/fonts/specimen/UnifrakturMaguntia'
+
+  font 'UnifrakturMaguntia-Book.ttf'
+end

--- a/Casks/font-unlock.rb
+++ b/Casks/font-unlock.rb
@@ -1,0 +1,11 @@
+cask 'font-unlock' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/unlock/Unlock-Regular.ttf'
+  name 'Unlock'
+  homepage 'http://www.google.com/fonts/specimen/Unlock'
+
+  font 'Unlock-Regular.ttf'
+end

--- a/Casks/font-unna.rb
+++ b/Casks/font-unna.rb
@@ -1,0 +1,11 @@
+cask 'font-unna' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/unna/Unna-Regular.ttf'
+  name 'Unna'
+  homepage 'http://www.google.com/fonts/specimen/Unna'
+
+  font 'Unna-Regular.ttf'
+end

--- a/Casks/font-vampiro-one.rb
+++ b/Casks/font-vampiro-one.rb
@@ -1,0 +1,11 @@
+cask 'font-vampiro-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/vampiroone/VampiroOne-Regular.ttf'
+  name 'Vampiro One'
+  homepage 'http://www.google.com/fonts/specimen/Vampiro+One'
+
+  font 'VampiroOne-Regular.ttf'
+end

--- a/Casks/font-varela-round.rb
+++ b/Casks/font-varela-round.rb
@@ -1,0 +1,11 @@
+cask 'font-varela-round' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/varelaround/VarelaRound-Regular.ttf'
+  name 'Varela Round'
+  homepage 'http://www.google.com/fonts/specimen/Varela+Round'
+
+  font 'VarelaRound-Regular.ttf'
+end

--- a/Casks/font-vast-shadow.rb
+++ b/Casks/font-vast-shadow.rb
@@ -1,0 +1,11 @@
+cask 'font-vast-shadow' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/vastshadow/VastShadow-Regular.ttf'
+  name 'Vast Shadow'
+  homepage 'http://www.google.com/fonts/specimen/Vast+Shadow'
+
+  font 'VastShadow-Regular.ttf'
+end

--- a/Casks/font-vibur.rb
+++ b/Casks/font-vibur.rb
@@ -1,0 +1,11 @@
+cask 'font-vibur' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/vibur/Vibur-Regular.ttf'
+  name 'Vibur'
+  homepage 'http://www.google.com/fonts/specimen/Vibur'
+
+  font 'Vibur-Regular.ttf'
+end

--- a/Casks/font-vidaloka.rb
+++ b/Casks/font-vidaloka.rb
@@ -1,0 +1,11 @@
+cask 'font-vidaloka' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/vidaloka/Vidaloka-Regular.ttf'
+  name 'Vidaloka'
+  homepage 'http://www.google.com/fonts/specimen/Vidaloka'
+
+  font 'Vidaloka-Regular.ttf'
+end

--- a/Casks/font-viga.rb
+++ b/Casks/font-viga.rb
@@ -1,0 +1,11 @@
+cask 'font-viga' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/viga/Viga-Regular.ttf'
+  name 'Viga'
+  homepage 'http://www.google.com/fonts/specimen/Viga'
+
+  font 'Viga-Regular.ttf'
+end

--- a/Casks/font-voces.rb
+++ b/Casks/font-voces.rb
@@ -1,0 +1,11 @@
+cask 'font-voces' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/voces/Voces-Regular.ttf'
+  name 'Voces'
+  homepage 'http://www.google.com/fonts/specimen/Voces'
+
+  font 'Voces-Regular.ttf'
+end

--- a/Casks/font-voltaire.rb
+++ b/Casks/font-voltaire.rb
@@ -1,0 +1,11 @@
+cask 'font-voltaire' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/voltaire/Voltaire-Regular.ttf'
+  name 'Voltaire'
+  homepage 'http://www.google.com/fonts/specimen/Voltaire'
+
+  font 'Voltaire-Regular.ttf'
+end

--- a/Casks/font-waiting-for-the-sunrise.rb
+++ b/Casks/font-waiting-for-the-sunrise.rb
@@ -1,0 +1,11 @@
+cask 'font-waiting-for-the-sunrise' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/waitingforthesunrise/WaitingfortheSunrise.ttf'
+  name 'Waiting for the Sunrise'
+  homepage 'http://www.google.com/fonts/specimen/Waiting+for+the+Sunrise'
+
+  font 'WaitingfortheSunrise.ttf'
+end

--- a/Casks/font-wallpoet.rb
+++ b/Casks/font-wallpoet.rb
@@ -1,0 +1,11 @@
+cask 'font-wallpoet' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/wallpoet/Wallpoet-Regular.ttf'
+  name 'Wallpoet'
+  homepage 'http://www.google.com/fonts/specimen/Wallpoet'
+
+  font 'Wallpoet-Regular.ttf'
+end

--- a/Casks/font-walter-turncoat.rb
+++ b/Casks/font-walter-turncoat.rb
@@ -1,0 +1,11 @@
+cask 'font-walter-turncoat' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/walterturncoat/WalterTurncoat.ttf'
+  name 'Walter Turncoat'
+  homepage 'http://www.google.com/fonts/specimen/Walter+Turncoat'
+
+  font 'WalterTurncoat.ttf'
+end

--- a/Casks/font-warnes.rb
+++ b/Casks/font-warnes.rb
@@ -1,0 +1,11 @@
+cask 'font-warnes' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/warnes/Warnes-Regular.ttf'
+  name 'Warnes'
+  homepage 'http://www.google.com/fonts/specimen/Warnes'
+
+  font 'Warnes-Regular.ttf'
+end

--- a/Casks/font-wellfleet.rb
+++ b/Casks/font-wellfleet.rb
@@ -1,0 +1,11 @@
+cask 'font-wellfleet' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/wellfleet/Wellfleet-Regular.ttf'
+  name 'Wellfleet'
+  homepage 'http://www.google.com/fonts/specimen/Wellfleet'
+
+  font 'Wellfleet-Regular.ttf'
+end

--- a/Casks/font-wendy-one.rb
+++ b/Casks/font-wendy-one.rb
@@ -1,0 +1,11 @@
+cask 'font-wendy-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/wendyone/WendyOne-Regular.ttf'
+  name 'Wendy One'
+  homepage 'http://www.google.com/fonts/specimen/Wendy+One'
+
+  font 'WendyOne-Regular.ttf'
+end

--- a/Casks/font-wire-one.rb
+++ b/Casks/font-wire-one.rb
@@ -1,0 +1,11 @@
+cask 'font-wire-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/wireone/WireOne.ttf'
+  name 'Wire One'
+  homepage 'http://www.google.com/fonts/specimen/Wire+One'
+
+  font 'WireOne.ttf'
+end

--- a/Casks/font-yellowtail.rb
+++ b/Casks/font-yellowtail.rb
@@ -1,0 +1,11 @@
+cask 'font-yellowtail' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/apache/yellowtail/Yellowtail-Regular.ttf'
+  name 'Yellowtail'
+  homepage 'http://www.google.com/fonts/specimen/Yellowtail'
+
+  font 'Yellowtail-Regular.ttf'
+end

--- a/Casks/font-yeseva-one.rb
+++ b/Casks/font-yeseva-one.rb
@@ -1,0 +1,11 @@
+cask 'font-yeseva-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/yesevaone/YesevaOne-Regular.ttf'
+  name 'Yeseva One'
+  homepage 'http://www.google.com/fonts/specimen/Yeseva+One'
+
+  font 'YesevaOne-Regular.ttf'
+end

--- a/Casks/font-yesteryear.rb
+++ b/Casks/font-yesteryear.rb
@@ -1,0 +1,11 @@
+cask 'font-yesteryear' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/yesteryear/Yesteryear-Regular.ttf'
+  name 'Yesteryear'
+  homepage 'http://www.google.com/fonts/specimen/Yesteryear'
+
+  font 'Yesteryear-Regular.ttf'
+end

--- a/Casks/font-zeyada.rb
+++ b/Casks/font-zeyada.rb
@@ -1,0 +1,11 @@
+cask 'font-zeyada' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/zeyada/Zeyada.ttf'
+  name 'Zeyada'
+  homepage 'http://www.google.com/fonts/specimen/Zeyada'
+
+  font 'Zeyada.ttf'
+end

--- a/font-cantora-one.rb
+++ b/font-cantora-one.rb
@@ -1,0 +1,11 @@
+cask 'font-cantora-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/cantoraone/CantoraOne-Regular.ttf'
+  name 'Cantora One'
+  homepage 'http://www.google.com/fonts/specimen/Cantora+One'
+
+  font 'CantoraOne-Regular.ttf'
+end

--- a/font-hammersmith-one.rb
+++ b/font-hammersmith-one.rb
@@ -1,0 +1,11 @@
+cask 'font-hammersmith-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/hammersmithone/HammersmithOne-Regular.ttf'
+  name 'Hammersmith One'
+  homepage 'http://www.google.com/fonts/specimen/Hammersmith+One'
+
+  font 'HammersmithOne-Regular.ttf'
+end

--- a/font-headland-one.rb
+++ b/font-headland-one.rb
@@ -1,0 +1,11 @@
+cask 'font-headland-one' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/headlandone/HeadlandOne-Regular.ttf'
+  name 'Headland One'
+  homepage 'http://www.google.com/fonts/specimen/Headland+One'
+
+  font 'HeadlandOne-Regular.ttf'
+end

--- a/font-moulpali.rb
+++ b/font-moulpali.rb
@@ -1,0 +1,11 @@
+cask 'font-moulpali' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/moulpali/Moulpali.ttf'
+  name 'Moulpali'
+  homepage 'http://www.google.com/fonts/specimen/Moulpali'
+
+  font 'Moulpali.ttf'
+end

--- a/font-odor-mean-chey.rb
+++ b/font-odor-mean-chey.rb
@@ -1,0 +1,11 @@
+cask 'font-odor-mean-chey' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/odormeanchey/OdorMeanChey.ttf'
+  name 'Odor Mean Chey'
+  homepage 'http://www.google.com/fonts/specimen/Odor+Mean+Chey'
+
+  font 'OdorMeanChey.ttf'
+end

--- a/font-preahvihear.rb
+++ b/font-preahvihear.rb
@@ -1,0 +1,11 @@
+cask 'font-preahvihear' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/preahvihear/Preahvihear.ttf'
+  name 'Preahvihear'
+  homepage 'http://www.google.com/fonts/specimen/Preahvihear'
+
+  font 'Preahvihear.ttf'
+end

--- a/font-sirin-stencil.rb
+++ b/font-sirin-stencil.rb
@@ -1,0 +1,11 @@
+cask 'font-sirin-stencil' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/raw/master/ofl/sirinstencil/SirinStencil-Regular.ttf'
+  name 'Sirin Stencil'
+  homepage 'http://www.google.com/fonts/specimen/Sirin+Stencil'
+
+  font 'SirinStencil-Regular.ttf'
+end


### PR DESCRIPTION
This PR solves the issue #445. The following steps has been done for each font:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

I've created a [fish script] that creates Casks with both automatization and supervision (for font names and URLs). The scripts test that every created cask can be installed and has the correct style.

Some Casks has been added with changes in their names:
- `font-fjord.rb` has been added as `font-fjord-one.rb`
- `font-supermercado.rb` has been added as `font-supermercado-one.rb`

Some Casks reflected in the original issue hasn't been added due that they have some problems or some tasks need to be done before upload them. They are the following:

- `font-bm-hanna.rb` doesn't exists in the `google/fonts` repo. It seems that now it's called [hanna] but I'm not sure
- `font-cantoraone`, `font-hammersmithone` and `font-headlandone` IMHO should be renamed to `font-cantora-one`, `font-hammersmith-one` and `font-headland-one` respectively
- `font-clara.rb`, `font-miama.rb` and  don't have an url in Google Fonts but they appear in the Google fonts repo
- `font-lao-muang-don.rb`, `font-lao-muang-khong.rb`, `font-lao-sans-pro.rb`, `font-tharlon` and `font-nanum-brush-script.rb` are marked as early access and they don't appear in the Google font catalog, you should navigate to early access fonts to find them.
- `font-moul-pali.rb` seems that should be renamed as `font-moulpali.rb` instead
- `font-nanum-pen.rb` seems that should be renamed as `font-nanum-pen-script.rb` instead and it's marked as an Early Access font (it doesn't appear in the Google fonts website)
- `font-odormeanchey.rb` seems that should be renamed as `font-odor-mean-chey.rb`
- `font-preah-vihear.rb` seems that should be renamed as `font-preahviear.rb`
- `font-sirinstencil.rb` seems that should be renamed as `font-sirin-stencil.rb`
- `font-souliyo-unicode.rb` has different name (`font-souliyo.rb`) and is marked as early access and it doesn't appear in the Google font catalog, you should navigate to early access fonts

And that's all. I don't know which is the correct way to address this tasks (open a different issue, update this PR...) so some advice would be really helpful in order to proceed.

Thanks!

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
[fish script]: https://gist.github.com/guerrero/b6c7fa8e92b54cbff34cda645202ade6
[hanna]: https://github.com/google/fonts/tree/49fbebd3dc75d42fe72c4a3eef6524f8fcc335fd/ofl/hanna