### PR TITLE
Update font-koruri to version 20161105

### DIFF
--- a/Casks/font-koruri.rb
+++ b/Casks/font-koruri.rb
@@ -1,11 +1,11 @@
 cask 'font-koruri' do
-  version '20160506,65771'
-  sha256 '15b72c803af963f72c838053a10bea1ae608b36ac9acaf2b69f7d924ee38181f'
+  version '20161105,66647'
+  sha256 '78e674e1b884189d60e378897179bec5164fa917c76adb53aa7931fc19a40074'
 
   # osdn.jp/koruri was verified as official when first introduced to the cask
   url "http://dl.osdn.jp/koruri/#{version.after_comma}/Koruri-#{version.before_comma}.tar.xz"
   appcast 'https://github.com/Koruri/Koruri/releases.atom',
-          checkpoint: 'af39d30f5b0ea590a879f63e7c34845bf57e1c555b69887af0e29f57e7e35729'
+          checkpoint: '745c593054d000272c9d15734b290cf564987b146df7a6c2294f98470a1b2105'
   name 'Koruri'
   homepage 'http://koruri.lindwurm.biz/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.