### PR TITLE
Update font-fira-mono.rb

### DIFF
--- a/Casks/font-fira-mono.rb
+++ b/Casks/font-fira-mono.rb
@@ -1,12 +1,15 @@
 cask 'font-fira-mono' do
   version '3.206'
-  sha256 'f14249f857d802d29844b9ebff764990665072cccef3748dce06b7c21be8c5fc'
+  sha256 'd86269657387f144d77ba12011124f30f423f70672e1576dc16f918bb16ddfe4'
 
-  url 'http://www.carrois.com/downloads/fira_mono_3_2/FiraMonoFonts3206.zip'
+  # github.com/mozilla/Fira was verified as official when first introduced to the cask
+  url 'https://github.com/mozilla/Fira/archive/4.202.tar.gz'
+  appcast 'https://github.com/mozilla/Fira/releases.atom',
+          checkpoint: '9e2d525c6d942160d9389752c3943eea9dbf886a2c7b651ae84d6524ede21d94'
   name 'Fira Mono'
-  homepage 'http://www.carrois.com/fira-4-1/'
+  homepage 'https://mozilla.github.io/Fira/'
 
-  font 'FiraMonoFonts3206/OTF/FiraMono-Bold.otf'
-  font 'FiraMonoFonts3206/OTF/FiraMono-Medium.otf'
-  font 'FiraMonoFonts3206/OTF/FiraMono-Regular.otf'
+  font 'Fira-4.202/otf/FiraMono-Bold.otf'
+  font 'Fira-4.202/otf/FiraMono-Medium.otf'
+  font 'Fira-4.202/otf/FiraMono-Regular.otf'
 end

--- a/Casks/font-fira-mono.rb
+++ b/Casks/font-fira-mono.rb
@@ -1,15 +1,15 @@
 cask 'font-fira-mono' do
-  version '3.206'
+  version '3.206,4.202'
   sha256 'd86269657387f144d77ba12011124f30f423f70672e1576dc16f918bb16ddfe4'
 
   # github.com/mozilla/Fira was verified as official when first introduced to the cask
-  url 'https://github.com/mozilla/Fira/archive/4.202.tar.gz'
+  url "https://github.com/mozilla/Fira/archive/#{version.after_comma}.tar.gz"
   appcast 'https://github.com/mozilla/Fira/releases.atom',
           checkpoint: '9e2d525c6d942160d9389752c3943eea9dbf886a2c7b651ae84d6524ede21d94'
   name 'Fira Mono'
   homepage 'https://mozilla.github.io/Fira/'
 
-  font 'Fira-4.202/otf/FiraMono-Bold.otf'
-  font 'Fira-4.202/otf/FiraMono-Medium.otf'
-  font 'Fira-4.202/otf/FiraMono-Regular.otf'
+  font "Fira-#{version.after_comma}/otf/FiraMono-Bold.otf"
+  font "Fira-#{version.after_comma}/otf/FiraMono-Medium.otf"
+  font "Fira-#{version.after_comma}/otf/FiraMono-Regular.otf"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Updates the cask style to use the official Mozilla appcast and homepage. We cannot use `#{version}` interpolation because the Mozilla releases do not distinguish well between Sans and Mono versions, but the 4.202 tarball _does_ contain Mono 3.206.