### PR TITLE
Add font-go, font-go-mono and font-go-medium

### DIFF
--- a/Casks/font-go-medium.rb
+++ b/Casks/font-go-medium.rb
@@ -1,0 +1,11 @@
+cask 'font-go-medium' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://go.googlesource.com/image/+archive/master/font/gofont/ttfs.tar.gz'
+  name 'Go Mono'
+  homepage 'https://go.googlesource.com/image/+/master/font/gofont/ttfs/README'
+
+  font 'Go-Medium.ttf'
+  font 'Go-Medium-Italic.ttf'
+end

--- a/Casks/font-go-mono.rb
+++ b/Casks/font-go-mono.rb
@@ -1,0 +1,13 @@
+cask 'font-go-mono' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://go.googlesource.com/image/+archive/master/font/gofont/ttfs.tar.gz'
+  name 'Go Mono'
+  homepage 'https://go.googlesource.com/image/+/master/font/gofont/ttfs/README'
+
+  font 'Go-Mono-Bold-Italic.ttf'
+  font 'Go-Mono-Bold.ttf'
+  font 'Go-Mono-Italic.ttf'
+  font 'Go-Mono.ttf'
+end

--- a/Casks/font-go.rb
+++ b/Casks/font-go.rb
@@ -1,0 +1,13 @@
+cask 'font-go' do
+  version :latest
+  sha256 :no_check
+
+  url 'https://go.googlesource.com/image/+archive/master/font/gofont/ttfs.tar.gz'
+  name 'Go Mono'
+  homepage 'https://go.googlesource.com/image/+/master/font/gofont/ttfs/README'
+
+  font 'Go-Bold-Italic.ttf'
+  font 'Go-Bold.ttf'
+  font 'Go-Italic.ttf'
+  font 'Go-Regular.ttf'
+end


### PR DESCRIPTION
Go released their new fonts for their experimental UI Toolkit (see: https://blog.golang.org/go-fonts). This PR aims to add those fonts to the cask/fonts repository. This font is licensed under the BSD License as the `golang` project itself (see: https://golang.org/LICENSE).

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [X] Named the cask according to the [token reference].
- [X] `brew cask install {{cask_file}}` worked successfully.
- [X] `brew cask uninstall {{cask_file}}` worked successfully.
- [X] Checked there are no [open pull requests] for the same cask.
- [X] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed

