### PR TITLE
Add font-mononoki

### DIFF
--- a/Casks/font-mononoki.rb
+++ b/Casks/font-mononoki.rb
@@ -4,6 +4,8 @@ cask 'font-mononoki' do
 
   # github.com/madmalik/mononoki was verified as official when first introduced to the cask
   url "https://github.com/madmalik/mononoki/releases/download/#{version}/mononoki.zip"
+  appcast 'https://github.com/madmalik/mononoki/releases.atom',
+          checkpoint: 'b32e98c9be92a1866cd13166f65040f84330ff12fd661939ad2a578f50358017'
   name 'Mononoki'
   homepage 'https://madmalik.github.io/mononoki/'
 

--- a/Casks/font-mononoki.rb
+++ b/Casks/font-mononoki.rb
@@ -1,0 +1,14 @@
+cask 'font-mononoki' do
+  version :latest
+  sha256 :no_check
+
+  # github.com/madmalik/mononoki was verified as official when first introduced to the cask
+  url 'https://github.com/madmalik/mononoki/raw/master/export/mononoki.zip'
+  name 'Mononoki'
+  homepage 'https://madmalik.github.io/mononoki/'
+
+  font 'mononoki-Bold.ttf'
+  font 'mononoki-BoldItalic.ttf'
+  font 'mononoki-Italic.ttf'
+  font 'mononoki-Regular.ttf'
+end

--- a/Casks/font-mononoki.rb
+++ b/Casks/font-mononoki.rb
@@ -1,9 +1,9 @@
 cask 'font-mononoki' do
-  version :latest
-  sha256 :no_check
+  version '1.2'
+  sha256 'cf29ea7663dbfe94feaedaf5c0be4f4ae6a5b98c1293e0e772e69c28ac5dc658'
 
   # github.com/madmalik/mononoki was verified as official when first introduced to the cask
-  url 'https://github.com/madmalik/mononoki/raw/master/export/mononoki.zip'
+  url "https://github.com/madmalik/mononoki/releases/download/#{version}/mononoki.zip"
   name 'Mononoki'
   homepage 'https://madmalik.github.io/mononoki/'
 


### PR DESCRIPTION
This is adding back the cask from #794 since the link is no longer dead.

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed

