### PR TITLE
Add font-free-hk-kai 1.01.

### DIFF
--- a/Casks/font-free-hk-kai.rb
+++ b/Casks/font-free-hk-kai.rb
@@ -1,0 +1,11 @@
+cask 'font-free-hk-kai' do
+  version '1.01'
+  sha256 'f949362df4c3e8d8f2f5e9c6e5932ce3aa4ab3176b3c0bfa61afbb8c7b750ada'
+
+  # github.com was verified as official when first introduced to the cask
+  url 'https://github.com/freehkfonts/freehkkai/raw/download/Free-HK-Kai_4700-v1.01.ttf'
+  name 'Free HK Kai'
+  homepage 'https://freehkfonts.opensource.hk/'
+
+  font 'Free-HK-Kai_4700-v1.01.ttf'
+end

--- a/Casks/font-free-hk-kai.rb
+++ b/Casks/font-free-hk-kai.rb
@@ -3,9 +3,9 @@ cask 'font-free-hk-kai' do
   sha256 'f949362df4c3e8d8f2f5e9c6e5932ce3aa4ab3176b3c0bfa61afbb8c7b750ada'
 
   # github.com was verified as official when first introduced to the cask
-  url 'https://github.com/freehkfonts/freehkkai/raw/download/Free-HK-Kai_4700-v1.01.ttf'
+  url "https://github.com/freehkfonts/freehkkai/raw/download/Free-HK-Kai_4700-v#{version}.ttf"
   name 'Free HK Kai'
   homepage 'https://freehkfonts.opensource.hk/'
 
-  font 'Free-HK-Kai_4700-v1.01.ttf'
+  font "Free-HK-Kai_4700-v#{version}.ttf"
 end


### PR DESCRIPTION
The official Chinese name of the font is "自由香港楷書 (4700字)".
License of the font is "CC BY 4.0" according to the README file at https://github.com/freehkfonts/freehkkai/blob/download/README.md

-----------

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
