### PR TITLE
Fix most of the out-of-date font cask installation issues

### DIFF
--- a/Casks/font-aclonica.rb
+++ b/Casks/font-aclonica.rb
@@ -3,7 +3,7 @@ cask 'font-aclonica' do
   sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/blob/master/apache/aclonica/Aclonica.ttf'
+  url 'https://github.com/google/fonts/raw/master/apache/aclonica/Aclonica.ttf'
   name 'Aclonica'
   homepage 'http://www.google.com/fonts/specimen/Aclonica'
 

--- a/Casks/font-adinatha-tamil-brahmi.rb
+++ b/Casks/font-adinatha-tamil-brahmi.rb
@@ -6,5 +6,5 @@ cask 'font-adinatha-tamil-brahmi' do
   name 'Adinatha Tamil Brahmi'
   homepage 'http://www.virtualvinodh.com/wp/tamil-brahmi-font/'
 
-  font 'Adinatha-Tamil-Brahmi.otf'
+  font 'Adinatha-Tamil-Brahmi/Adinatha-Tamil-Brahmi.otf'
 end

--- a/Casks/font-andika.rb
+++ b/Casks/font-andika.rb
@@ -2,9 +2,9 @@ cask 'font-andika' do
   version '5.000'
   sha256 '604b7a1194be099bdf311ef76cbce086a054fa16d2b101cfaedcf527c63df507'
 
-  url "http://software.sil.org/downloads/andika/Andika-#{version}.zip"
+  url "http://software.sil.org/downloads/d/andika/Andika-#{version}.zip"
   name 'Andika'
   homepage 'http://software.sil.org/andika/'
 
-  font 'Andika-#{version}/Andika-R.ttf'
+  font "Andika-#{version}/Andika-R.ttf"
 end

--- a/Casks/font-antinoou.rb
+++ b/Casks/font-antinoou.rb
@@ -1,5 +1,5 @@
 cask 'font-antinoou' do
-  version '1.006'
+  version '1.0.6'
   sha256 'd7f961ff2ab5b6c707e4f0a24e8302c7a61c2e2ab2e9880c94a8deb6f5aeff69'
 
   url 'http://www.evertype.com/fonts/coptic/AntinoouFont.zip'

--- a/Casks/font-anton.rb
+++ b/Casks/font-anton.rb
@@ -3,9 +3,9 @@ cask 'font-anton' do
   sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/raw/master/ofl/anton/Anton.ttf'
+  url 'https://github.com/google/fonts/raw/master/ofl/anton/Anton-Regular.ttf'
   name 'Anton'
   homepage 'http://www.google.com/fonts/specimen/Anton'
 
-  font 'Anton.ttf'
+  font 'Anton-Regular.ttf'
 end

--- a/Casks/font-babelstone-modern.rb
+++ b/Casks/font-babelstone-modern.rb
@@ -2,7 +2,7 @@ cask 'font-babelstone-modern' do
   version :latest
   sha256 :no_check
 
-  url 'http://babelstone.co.uk/Fonts/5521/BabelStoneModern.zip'
+  url 'http://babelstone.co.uk/Fonts/5521/BabelStoneModern.ttf'
   name 'BabelStone Modern'
   homepage 'http://www.babelstone.co.uk/Fonts/'
 

--- a/Casks/font-baloo.rb
+++ b/Casks/font-baloo.rb
@@ -1,6 +1,6 @@
 cask 'font-baloo' do
   version '1.100'
-  sha256 'd3d7d7bc721ce512f286e3ea8f67aa98d2a0c21327306315ebddf51327b3135b'
+  sha256 'b94636ce261ca2f532791fa167c5cfe98dcca1f434996c69b5354ab700faa0d7'
 
   url "https://github.com/EkType/Baloo/releases/download/1.10/Baloo_#{version}.zip"
   name 'Baloo'
@@ -8,6 +8,7 @@ cask 'font-baloo' do
 
   font 'Baloo-Regular.ttf'
   font 'BalooBhai-Regular.ttf'
+  font 'BalooBhaijaan-Regular.ttf'
   font 'BalooBhaina-Regular.ttf'
   font 'BalooChettan-Regular.ttf'
   font 'BalooDa-Regular.ttf'

--- a/Casks/font-bangers.rb
+++ b/Casks/font-bangers.rb
@@ -3,9 +3,9 @@ cask 'font-bangers' do
   sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/raw/master/ofl/bangers/Bangers.ttf'
+  url 'https://github.com/google/fonts/raw/master/ofl/bangers/Bangers-Regular.ttf'
   name 'Bangers'
   homepage 'http://www.google.com/fonts/specimen/Bangers'
 
-  font 'Bangers.ttf'
+  font 'Bangers-Regular.ttf'
 end

--- a/Casks/font-bevan.rb
+++ b/Casks/font-bevan.rb
@@ -3,9 +3,9 @@ cask 'font-bevan' do
   sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/raw/master/ofl/bevan/Bevan.ttf'
+  url 'https://github.com/google/fonts/raw/master/ofl/bevan/Bevan-Regular.ttf'
   name 'Bevan'
   homepage 'http://www.google.com/fonts/specimen/Bevan'
 
-  font 'Bevan.ttf'
+  font 'Bevan-Regular.ttf'
 end

--- a/Casks/font-bungee.rb
+++ b/Casks/font-bungee.rb
@@ -1,27 +1,27 @@
 cask 'font-bungee' do
-  version '1.0'
-  sha256 'd5b2a8c80fdab2420bcec03cd4b78451fa10299daea305ff33618d371aa8a62c'
+  version '1.1.0'
+  sha256 'd012a9e6293201c3165feba64342d29c42bb4e67b1cc66e07509c12bab760a6f'
 
   # github.com/djrrb/bungee was verified as official when first introduced to the cask
-  url "https://github.com/djrrb/bungee/releases/download/v#{version}/Bungee-fonts.zip"
+  url "https://github.com/djrrb/Bungee/releases/download/#{version}/Bungee-fonts.zip"
   appcast 'https://github.com/djrrb/bungee/releases.atom',
-          checkpoint: '344b7d19c095589fcf158c7ab4cca696ef4377628aeb14027da0bc61fa40c4d3'
+          checkpoint: '5bf9a5c1e404893bc4b5fa3681f7622b8f4998246ebcf5ffb9a48cb1798ec71e'
   name 'Bungee'
   homepage 'https://djr.com/bungee/'
 
-  font 'Bungee-fonts/Bungee_Color_Fonts/BungeeColor-Regular_sbix_MacOS.ttf'
-  font 'Bungee-fonts/Bungee_Color_Fonts/BungeeColor-Regular_svg.ttf'
-  font 'Bungee-fonts/Bungee_Desktop/Bungee/Bungee-Hairline.otf'
-  font 'Bungee-fonts/Bungee_Desktop/Bungee/Bungee-Inline.otf'
-  font 'Bungee-fonts/Bungee_Desktop/Bungee/Bungee-Outline.otf'
-  font 'Bungee-fonts/Bungee_Desktop/Bungee/Bungee-Regular.otf'
-  font 'Bungee-fonts/Bungee_Desktop/Bungee/Bungee-Shade.otf'
-  font 'Bungee-fonts/Bungee_Desktop/BungeeLayers/BungeeLayers-Inline.otf'
-  font 'Bungee-fonts/Bungee_Desktop/BungeeLayers/BungeeLayers-Outline.otf'
-  font 'Bungee-fonts/Bungee_Desktop/BungeeLayers/BungeeLayers-Regular.otf'
-  font 'Bungee-fonts/Bungee_Desktop/BungeeLayers/BungeeLayers-Shade.otf'
-  font 'Bungee-fonts/Bungee_Desktop/BungeeLayersRotated/BungeeLayersRotated-Inline.otf'
-  font 'Bungee-fonts/Bungee_Desktop/BungeeLayersRotated/BungeeLayersRotated-Outline.otf'
-  font 'Bungee-fonts/Bungee_Desktop/BungeeLayersRotated/BungeeLayersRotated-Regular.otf'
-  font 'Bungee-fonts/Bungee_Desktop/BungeeLayersRotated/BungeeLayersRotated-Shade.otf'
+  font 'fonts/Bungee_Color_Fonts/BungeeColor-Regular_sbix_MacOS.ttf'
+  font 'fonts/Bungee_Color_Fonts/BungeeColor-Regular_svg.ttf'
+  font 'fonts/Bungee_Desktop/Bungee/Bungee-Hairline.otf'
+  font 'fonts/Bungee_Desktop/Bungee/Bungee-Inline.otf'
+  font 'fonts/Bungee_Desktop/Bungee/Bungee-Outline.otf'
+  font 'fonts/Bungee_Desktop/Bungee/Bungee-Regular.otf'
+  font 'fonts/Bungee_Desktop/Bungee/Bungee-Shade.otf'
+  font 'fonts/Bungee_Desktop/BungeeLayers/BungeeLayers-Inline.otf'
+  font 'fonts/Bungee_Desktop/BungeeLayers/BungeeLayers-Outline.otf'
+  font 'fonts/Bungee_Desktop/BungeeLayers/BungeeLayers-Regular.otf'
+  font 'fonts/Bungee_Desktop/BungeeLayers/BungeeLayers-Shade.otf'
+  font 'fonts/Bungee_Desktop/BungeeLayersRotated/BungeeLayersRotated-Inline.otf'
+  font 'fonts/Bungee_Desktop/BungeeLayersRotated/BungeeLayersRotated-Outline.otf'
+  font 'fonts/Bungee_Desktop/BungeeLayersRotated/BungeeLayersRotated-Regular.otf'
+  font 'fonts/Bungee_Desktop/BungeeLayersRotated/BungeeLayersRotated-Shade.otf'
 end

--- a/Casks/font-bungee.rb
+++ b/Casks/font-bungee.rb
@@ -5,7 +5,7 @@ cask 'font-bungee' do
   # github.com/djrrb/bungee was verified as official when first introduced to the cask
   url "https://github.com/djrrb/Bungee/releases/download/#{version}/Bungee-fonts.zip"
   appcast 'https://github.com/djrrb/bungee/releases.atom',
-          checkpoint: '5bf9a5c1e404893bc4b5fa3681f7622b8f4998246ebcf5ffb9a48cb1798ec71e'
+          checkpoint: '5f9133d0ed5ba7461c6d3aba4e7d2706951ce25121a8c43ab4bf5f971d1d3f96'
   name 'Bungee'
   homepage 'https://djr.com/bungee/'
 

--- a/Casks/font-bungee.rb
+++ b/Casks/font-bungee.rb
@@ -3,7 +3,7 @@ cask 'font-bungee' do
   sha256 'd012a9e6293201c3165feba64342d29c42bb4e67b1cc66e07509c12bab760a6f'
 
   # github.com/djrrb/bungee was verified as official when first introduced to the cask
-  url "https://github.com/djrrb/Bungee/releases/download/#{version}/Bungee-fonts.zip"
+  url "https://github.com/djrrb/bungee/releases/download/#{version}/Bungee-fonts.zip"
   appcast 'https://github.com/djrrb/bungee/releases.atom',
           checkpoint: '5f9133d0ed5ba7461c6d3aba4e7d2706951ce25121a8c43ab4bf5f971d1d3f96'
   name 'Bungee'

--- a/Casks/font-calligraffitti.rb
+++ b/Casks/font-calligraffitti.rb
@@ -3,7 +3,7 @@ cask 'font-calligraffitti' do
   sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/blob/master/apache/calligraffitti/Calligraffitti-Regular.ttf'
+  url 'https://github.com/google/fonts/raw/master/apache/calligraffitti/Calligraffitti-Regular.ttf'
   name 'Calligraffitti'
   homepage 'http://www.google.com/fonts/specimen/Calligraffitti'
 

--- a/Casks/font-cutive-mono.rb
+++ b/Casks/font-cutive-mono.rb
@@ -1,6 +1,6 @@
 cask 'font-cutive-mono' do
-  version '1.002'
-  sha256 'ef9633aae944f29d936f5da3d757fa6b00cad4948fe8891a093788c2f3524bba'
+  version :latest
+  sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
   url 'https://github.com/google/fonts/raw/master/ofl/cutivemono/CutiveMono-Regular.ttf'

--- a/Casks/font-francois-one.rb
+++ b/Casks/font-francois-one.rb
@@ -3,9 +3,9 @@ cask 'font-francois-one' do
   sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/raw/master/ofl/francoisone/FrancoisOne.ttf'
+  url 'https://github.com/google/fonts/raw/master/ofl/francoisone/FrancoisOne-Regular.ttf'
   name 'Francois One'
   homepage 'http://www.google.com/fonts/specimen/Francois+One'
 
-  font 'FrancoisOne.ttf'
+  font 'FrancoisOne-Regular.ttf'
 end

--- a/Casks/font-gandom.rb
+++ b/Casks/font-gandom.rb
@@ -5,7 +5,7 @@ cask 'font-gandom' do
   # github.com/rastikerdar was verified as official when first introduced to the cask
   url "https://github.com/rastikerdar/gandom-font/releases/download/v#{version}/gandom-font-v#{version}.zip"
   appcast 'https://github.com/rastikerdar/gandom-font/releases.atom',
-          checkpoint: '3752706138e6ce47c9c3470ee86ecd6e8841ddec24f00783602bf578f8697a24'
+          checkpoint: 'ad2a2478a782726dd4f8629cff19c36f83e3dff204ec3aeafc19ce3feaf9876b'
   name 'Gandom'
   homepage 'http://rastikerdar.github.io/gandom-font'
 

--- a/Casks/font-gandom.rb
+++ b/Casks/font-gandom.rb
@@ -1,14 +1,13 @@
 cask 'font-gandom' do
-  version '0.4.4'
-  sha256 'ae2ed95be9915b44c10f8a7d33763cecf29683464ecee4b60fcfcf1516ad3a8f'
+  version '0.4.5'
+  sha256 '4ea2ca208312e405252c8b8373b2a1bab1158f3f5388650a1ac89e195a1b42f0'
 
   # github.com/rastikerdar was verified as official when first introduced to the cask
   url "https://github.com/rastikerdar/gandom-font/releases/download/v#{version}/gandom-font-v#{version}.zip"
   appcast 'https://github.com/rastikerdar/gandom-font/releases.atom',
-          checkpoint: '1c534d1ac2cb060a5b2ac93839fcb411f84fefb65cf0555d805060270280c0ba'
+          checkpoint: '3752706138e6ce47c9c3470ee86ecd6e8841ddec24f00783602bf578f8697a24'
   name 'Gandom'
   homepage 'http://rastikerdar.github.io/gandom-font'
 
   font 'Gandom.ttf'
-  font 'Gandom-Bold.ttf'
 end

--- a/Casks/font-gidole.rb
+++ b/Casks/font-gidole.rb
@@ -3,9 +3,9 @@ cask 'font-gidole' do
   sha256 :no_check
 
   # github.com/gidole was verified as official when first introduced to the cask
-  url 'https://github.com/andreaslarsen/Gidole/blob/master/gidole.zip?raw=true'
-  appcast 'https://github.com/larsenwork/Gidole/releases.atom',
-          checkpoint: '4e4eff702b684544677877d723125b669243b2f3468179a62772dcb3b529e70d'
+  url 'https://github.com/gidole/Gidole-Typefaces/raw/master/gidole.zip'
+  appcast 'https://github.com/gidole/Gidole-Typefaces/releases.atom',
+          checkpoint: '1df38a5178b492b9843b8bc31393e1bd7cb6f4b71e682a6144dea19d244aa9f0'
   name 'Gidole'
   homepage 'https://gidole.github.io'
 

--- a/Casks/font-gidole.rb
+++ b/Casks/font-gidole.rb
@@ -3,12 +3,12 @@ cask 'font-gidole' do
   sha256 :no_check
 
   # github.com/gidole was verified as official when first introduced to the cask
-  url 'https://github.com/gidole/sans/blob/master/gidole.zip?raw=true'
+  url 'https://github.com/andreaslarsen/Gidole/blob/master/gidole.zip?raw=true'
   appcast 'https://github.com/larsenwork/Gidole/releases.atom',
-          checkpoint: '1df38a5178b492b9843b8bc31393e1bd7cb6f4b71e682a6144dea19d244aa9f0'
+          checkpoint: '4e4eff702b684544677877d723125b669243b2f3468179a62772dcb3b529e70d'
   name 'Gidole'
   homepage 'https://gidole.github.io'
 
-  font 'Gidole-Regular.ttf'
-  font 'Gidolinya-Regular.ttf'
+  font 'GidoleFont/Gidole-Regular.ttf'
+  font 'GidoleFont/Gidolinya-Regular.otf'
 end

--- a/Casks/font-kacstone.rb
+++ b/Casks/font-kacstone.rb
@@ -7,6 +7,6 @@ cask 'font-kacstone' do
   name 'KacstOne'
   homepage 'http://projects.arabeyes.org/project.php?proj=Khotot'
 
-  font 'KacstOne.ttf'
-  font 'KacstOne-Bold.ttf'
+  font "kacst_one_#{version}/KacstOne.ttf"
+  font "kacst_one_#{version}/KacstOne-Bold.ttf"
 end

--- a/Casks/font-lalezar.rb
+++ b/Casks/font-lalezar.rb
@@ -2,11 +2,11 @@ cask 'font-lalezar' do
   version '1.003'
   sha256 'e2c758bd395b08d5cb440167d35b264d1393c26bab6854eab484672c09f10f42'
 
-  url "https://codeload.github.com/BornaIz/Lalezar/zip/#{version}"
+  url "https://github.com/BornaIz/Lalezar/archive/#{version}.zip"
   appcast 'https://github.com/BornaIz/Lalezar/releases.atom',
           checkpoint: '66aba340c111d02166d12a98bbaf7a8d0dee693afbae54e56be4799804cd2144'
   name 'Lalezar'
   homepage 'https://github.com/BornaIz/Lalezar'
 
-  font "Lalezar-v#{version}-fonts/Font files/Lalezar-Regular.otf"
+  font "Lalezar-#{version}/Font files/Lalezar-Regular.otf"
 end

--- a/Casks/font-metrophobic.rb
+++ b/Casks/font-metrophobic.rb
@@ -3,9 +3,9 @@ cask 'font-metrophobic' do
   sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/raw/master/ofl/metrophobic/Metrophobic.ttf'
+  url 'https://github.com/google/fonts/raw/master/ofl/metrophobic/Metrophobic-Regular.ttf'
   name 'Metrophobic'
   homepage 'http://www.google.com/fonts/specimen/Metrophobic'
 
-  font 'Metrophobic.ttf'
+  font 'Metrophobic-Regular.ttf'
 end

--- a/Casks/font-nika.rb
+++ b/Casks/font-nika.rb
@@ -8,5 +8,5 @@ cask 'font-nika' do
   name 'Nika'
   homepage 'https://github.com/font-store/font-nika'
 
-  font "fonts/Nika-Regular.otf"
+  font 'fonts/Nika-Regular.otf'
 end

--- a/Casks/font-nika.rb
+++ b/Casks/font-nika.rb
@@ -1,12 +1,12 @@
 cask 'font-nika' do
   version '1.0.0'
-  sha256 '0ef9ec73a2406bc81405ea0bbdd81095f0543c6d79c46bc2246f72c7ebf551ba'
+  sha256 'a0e435a23fe971eddb3f39883c606c92b43f9a7b1fc0d762509a291996960d2b'
 
-  url "https://github.com/font-store/font-nika/archive/v#{version}.zip"
+  url "https://github.com/font-store/NikaFont/releases/download/v#{version}/nika.v#{version}.zip"
   appcast 'https://github.com/font-store/font-nika/releases.atom',
-          checkpoint: 'a8141f7742de3164736c5e9b5d6da7d9cc2902e649653f1334d3bcedc70f1dd3'
+          checkpoint: '6a4efdd5658653cc8b20a6fa03350f4225e796efbbea5a96c2f4b4e61cb9327b'
   name 'Nika'
   homepage 'https://github.com/font-store/font-nika'
 
-  font "font-nika-#{version}/dist/Nika-Regular.otf"
+  font "fonts/Nika-Regular.otf"
 end

--- a/Casks/font-nika.rb
+++ b/Casks/font-nika.rb
@@ -4,7 +4,7 @@ cask 'font-nika' do
 
   url "https://github.com/font-store/NikaFont/releases/download/v#{version}/nika.v#{version}.zip"
   appcast 'https://github.com/font-store/font-nika/releases.atom',
-          checkpoint: '6a4efdd5658653cc8b20a6fa03350f4225e796efbbea5a96c2f4b4e61cb9327b'
+          checkpoint: '9c2bba39e9b30c65f708a26a4aa3bec03ef276f0c878115cc6252dd86756e4f1'
   name 'Nika'
   homepage 'https://github.com/font-store/font-nika'
 

--- a/Casks/font-noto-sans-cuneiform.rb
+++ b/Casks/font-noto-sans-cuneiform.rb
@@ -7,5 +7,5 @@ cask 'font-noto-sans-cuneiform' do
   name 'Noto Sans Cuneiform'
   homepage 'https://www.google.com/get/noto/#sans-xsux'
 
-  font 'NotoSansCypriot-Regular.ttf'
+  font 'NotoSansCuneiform-Regular.ttf'
 end

--- a/Casks/font-noto-sans-inscriptional-pahlavi.rb
+++ b/Casks/font-noto-sans-inscriptional-pahlavi.rb
@@ -7,5 +7,5 @@ cask 'font-noto-sans-inscriptional-pahlavi' do
   name 'Noto Sans Inscriptional Pahlavi'
   homepage 'https://www.google.com/get/noto/#sans-phli'
 
-  font 'NotoSansPahlavi-Regular.ttf'
+  font 'NotoSansInscriptionalPahlavi-Regular.ttf'
 end

--- a/Casks/font-noto-sans-inscriptional-parthian.rb
+++ b/Casks/font-noto-sans-inscriptional-parthian.rb
@@ -7,5 +7,5 @@ cask 'font-noto-sans-inscriptional-parthian' do
   name 'Noto Sans Inscriptional Parthian'
   homepage 'https://www.google.com/get/noto/#sans-prti'
 
-  font 'NotoSansParthian-Regular.ttf'
+  font 'NotoSansInscriptionalParthian-Regular.ttf'
 end

--- a/Casks/font-ocra.rb
+++ b/Casks/font-ocra.rb
@@ -7,11 +7,8 @@ cask 'font-ocra' do
   name 'OCRA'
   homepage 'http://ansuz.sooke.bc.ca/page/fonts#ocra'
 
-  font "ocr-#{version}/OCRA.otf"
-  font "ocr-#{version}/OCRB.otf"
-  font "ocr-#{version}/OCRBE.otf"
-  font "ocr-#{version}/OCRBF.otf"
-  font "ocr-#{version}/OCRBL.otf"
-  font "ocr-#{version}/OCRBS.otf"
-  font "ocr-#{version}/OCRBX.otf"
+  font "TsukurimashouKaku.otf"
+  font "TsukurimashouKakuPS.otf"
+  font "TsukurimashouMincho.otf"
+  font "TsukurimashouMinchoPS.otf"
 end

--- a/Casks/font-ocra.rb
+++ b/Casks/font-ocra.rb
@@ -7,8 +7,8 @@ cask 'font-ocra' do
   name 'OCRA'
   homepage 'http://ansuz.sooke.bc.ca/page/fonts#ocra'
 
-  font "TsukurimashouKaku.otf"
-  font "TsukurimashouKakuPS.otf"
-  font "TsukurimashouMincho.otf"
-  font "TsukurimashouMinchoPS.otf"
+  font 'TsukurimashouKaku.otf'
+  font 'TsukurimashouKakuPS.otf'
+  font 'TsukurimashouMincho.otf'
+  font 'TsukurimashouMinchoPS.otf'
 end

--- a/Casks/font-pacifico.rb
+++ b/Casks/font-pacifico.rb
@@ -3,9 +3,9 @@ cask 'font-pacifico' do
   sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/raw/master/ofl/pacifico/Pacifico.ttf'
+  url 'https://github.com/google/fonts/raw/master/ofl/pacifico/Pacifico-Regular.ttf'
   name 'Pacifico'
   homepage 'http://www.google.com/fonts/specimen/Pacifico'
 
-  font 'Pacifico.ttf'
+  font 'Pacifico-Regular.ttf'
 end

--- a/Casks/font-redacted.rb
+++ b/Casks/font-redacted.rb
@@ -2,15 +2,12 @@ cask 'font-redacted' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/christiannaths/Redacted-Font/trunk/fonts',
-      using:      :svn,
-      revision:   '41',
-      trust_cert: true
+  url 'https://github.com/christiannaths/Redacted-Font/archive/old-sources.zip'
   name 'Redacted'
   homepage 'https://github.com/christiannaths/Redacted-Font'
 
-  font 'redacted-regular.ttf'
-  font 'redacted-script-bold.ttf'
-  font 'redacted-script-light.ttf'
-  font 'redacted-script-regular.ttf'
+  font 'Redacted-Font-old-sources/fonts/redacted-regular.ttf'
+  font 'Redacted-Font-old-sources/fonts/redacted-script-bold.ttf'
+  font 'Redacted-Font-old-sources/fonts/redacted-script-light.ttf'
+  font 'Redacted-Font-old-sources/fonts/redacted-script-regular.ttf'
 end

--- a/Casks/font-rotinonhsonni-sans.rb
+++ b/Casks/font-rotinonhsonni-sans.rb
@@ -1,5 +1,5 @@
 cask 'font-rotinonhsonni-sans' do
-  version '8.7.2001'
+  version '8.7.2.2001'
   sha256 'c1edbe62bca1e33b6835073610b2a39e1bc41b41eeb438aa918941cd12d3785c'
 
   url 'http://www.languagegeek.com/font/RotinonhSans.zip'

--- a/Casks/font-share-tech.rb
+++ b/Casks/font-share-tech.rb
@@ -1,6 +1,6 @@
 cask 'font-share-tech' do
-  version '1.002'
-  sha256 '59bc26a1c7783052927b84c98c757d1c81a2d93b1c5259a0f669ec873397415c'
+  version :latest
+  sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
   url 'https://github.com/google/fonts/raw/master/ofl/sharetech/ShareTech-Regular.ttf'

--- a/Casks/font-sigmar-one.rb
+++ b/Casks/font-sigmar-one.rb
@@ -3,9 +3,9 @@ cask 'font-sigmar-one' do
   sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/raw/master/ofl/sigmarone/SigmarOne.ttf'
+  url 'https://github.com/google/fonts/raw/master/ofl/sigmarone/SigmarOne-Regular.ttf'
   name 'Sigmar One'
   homepage 'http://www.google.com/fonts/specimen/Sigmar+One'
 
-  font 'SigmarOne.ttf'
+  font 'SigmarOne-Regular.ttf'
 end

--- a/Casks/font-takaoex.rb
+++ b/Casks/font-takaoex.rb
@@ -6,6 +6,6 @@ cask 'font-takaoex' do
   name 'TakaoEx'
   homepage 'https://launchpad.net/takao-fonts'
 
-  font 'TakaoExGothic.ttf'
-  font 'TakaoExMincho.ttf'
+  font "TakaoExFonts_#{version}/TakaoExGothic.ttf"
+  font "TakaoExFonts_#{version}/TakaoExMincho.ttf"
 end

--- a/Casks/font-twitter-color-emoji.rb
+++ b/Casks/font-twitter-color-emoji.rb
@@ -8,5 +8,5 @@ cask 'font-twitter-color-emoji' do
   name 'Twitter Color Emoji'
   homepage 'https://github.com/eosrei/twemoji-color-font/'
 
-  font 'TwitterColorEmoji-SVGinOT-#{version}/TwitterColorEmoji-SVGinOT.ttf'
+  font "TwitterColorEmoji-SVGinOT-#{version}/TwitterColorEmoji-SVGinOT.ttf"
 end

--- a/Casks/font-vt323.rb
+++ b/Casks/font-vt323.rb
@@ -1,6 +1,6 @@
 cask 'font-vt323' do
-  version '001.002'
-  sha256 '214c2bbd6f7d1a9787413a01dccdf6134fd1ed7934e425d07c2ad32b1568979a'
+  version :latest
+  sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
   url 'https://github.com/google/fonts/raw/master/ofl/vt323/VT323-Regular.ttf'


### PR DESCRIPTION
*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
No, the casks are legacy and many of them violate naming rule, etc. that I don't touch.
- [ ] The commit message includes the cask’s name and version.
No, casks are many. I can list them in the PR if necessary.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
