### PR TITLE
Update font-inconsolata to new url

### DIFF
--- a/Casks/font-inconsolata.rb
+++ b/Casks/font-inconsolata.rb
@@ -2,9 +2,13 @@ cask 'font-inconsolata' do
   version :latest
   sha256 :no_check
 
-  url 'http://levien.com/type/myfonts/Inconsolata.otf'
+  # github.com/google/fonts was verified as official when first introduced to the cask
+  url 'https://github.com/google/fonts/trunk/ofl/inconsolata',
+      using:      :svn,
+      trust_cert: true
   name 'Inconsolata'
   homepage 'http://levien.com/type/myfonts/inconsolata.html'
 
-  font 'Inconsolata.otf'
+  font 'Inconsolata-Regular.ttf'
+  font 'Inconsolata-Bold.ttf'
 end


### PR DESCRIPTION
Use Google Web Font Directory as noted on the author's website.

Google Web Font Directory is now the official upstream for Inconsolata and the one directly linked from the author's website is now outdated.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.
  => Include only cask name since the version is just 'latest' and the change is not related to the version number.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked that the cask was not already refused in [closed issues].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
