### PR TITLE
Added `Doulos SIL` font v5.000

### DIFF
--- a/Casks/font-doulos-sil.rb
+++ b/Casks/font-doulos-sil.rb
@@ -1,0 +1,10 @@
+cask 'font-doulos-sil' do
+  version '5.000'
+  sha256 '0b309c3db813a98ce884c0bd25c7f5c0bd96bbffd076459e39298812ca22472e'
+
+  url "http://software.sil.org/downloads/d/doulos/DoulosSIL-#{version}.zip"
+  name 'Doulos SIL'
+  homepage 'http://software.sil.org/doulos/'
+
+  font "DoulosSIL-#{version}/DoulosSIL-R.ttf"
+end


### PR DESCRIPTION
Doulos SIL is a font that supports  wide range of languages that use
the Latin and Cyrillic scripts, whether used for phonetic or
orthographic needs. Linguists appreciate the wide range of characters
and symbols useful in their work. This font makes use of
state-of-the-art font technologies to support complex typographic
issues, such as the need to position arbitrary combinations of base
glyphs and diacritics optimally.

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download font-doulos-sil` is error-free.
- [x] `brew cask style --fix font-doulos-sil` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, **if adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install font-doulos-sil` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
