### PR TITLE
Update homepage/URL for font-liberation-sans

### DIFF
--- a/Casks/font-liberation-sans.rb
+++ b/Casks/font-liberation-sans.rb
@@ -2,9 +2,9 @@ cask 'font-liberation-sans' do
   version '2.00.1'
   sha256 '7890278a6cd17873c57d9cd785c2d230d9abdea837e96516019c5885dd271504'
 
-  url "https://fedorahosted.org/releases/l/i/liberation-fonts/liberation-fonts-ttf-#{version}.tar.gz"
+  url "https://releases.pagure.org/liberation-fonts/liberation-fonts-ttf-#{version}.tar.gz"
   name 'Liberation Sans'
-  homepage 'https://fedorahosted.org/liberation-fonts/'
+  homepage 'https://pagure.io/liberation-fonts/'
 
   font "liberation-fonts-ttf-#{version}/LiberationMono-Bold.ttf"
   font "liberation-fonts-ttf-#{version}/LiberationMono-BoldItalic.ttf"

--- a/Casks/font-liberation-sans.rb
+++ b/Casks/font-liberation-sans.rb
@@ -2,6 +2,7 @@ cask 'font-liberation-sans' do
   version '2.00.1'
   sha256 '7890278a6cd17873c57d9cd785c2d230d9abdea837e96516019c5885dd271504'
 
+  # releases.pagure.org/liberation-fonts was verified as official when first introduced to the cask
   url "https://releases.pagure.org/liberation-fonts/liberation-fonts-ttf-#{version}.tar.gz"
   name 'Liberation Sans'
   homepage 'https://pagure.io/liberation-fonts/'


### PR DESCRIPTION
fedorahosted.org was shut down, liberation fonts were moved to pagure.io

*If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so.*

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version (no version changed)

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
