### PR TITLE
Update font-arial to 2.82

### DIFF
--- a/Casks/font-arial.rb
+++ b/Casks/font-arial.rb
@@ -3,6 +3,8 @@ cask 'font-arial' do
   sha256 '85297a4d146e9c87ac6f74822734bdee5f4b2a722d7eaa584b7f2cbf76f478f6'
 
   url 'https://downloads.sourceforge.net/corefonts/arial32.exe'
+  appcast 'https://sourceforge.net/projects/corefonts/rss',
+          checkpoint: '8d659740c2893218b3e1d16918a9372b2838f5e0e7ef0405d3103f2d563e7bd1'
   name 'Arial'
   homepage 'http://sourceforge.net/projects/corefonts/files/the%20fonts/final/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.