### PR TITLE
Update font-arial-black to 2.35

### DIFF
--- a/Casks/font-arial-black.rb
+++ b/Casks/font-arial-black.rb
@@ -3,6 +3,8 @@ cask 'font-arial-black' do
   sha256 'a425f0ffb6a1a5ede5b979ed6177f4f4f4fdef6ae7c302a7b7720ef332fec0a8'
 
   url 'https://downloads.sourceforge.net/corefonts/arialb32.exe'
+  appcast 'https://sourceforge.net/projects/corefonts/rss',
+          checkpoint: '8d659740c2893218b3e1d16918a9372b2838f5e0e7ef0405d3103f2d563e7bd1'
   name 'Arial Black'
   homepage 'http://sourceforge.net/projects/corefonts/files/the%20fonts/final/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.