### PR TITLE
Update font-courier-new to 2.82

### DIFF
--- a/Casks/font-courier-new.rb
+++ b/Casks/font-courier-new.rb
@@ -3,6 +3,8 @@ cask 'font-courier-new' do
   sha256 'bb511d861655dde879ae552eb86b134d6fae67cb58502e6ff73ec5d9151f3384'
 
   url 'https://downloads.sourceforge.net/corefonts/courie32.exe'
+  appcast 'https://sourceforge.net/projects/corefonts/rss',
+          checkpoint: '8d659740c2893218b3e1d16918a9372b2838f5e0e7ef0405d3103f2d563e7bd1'
   name 'Courier New'
   homepage 'http://sourceforge.net/projects/corefonts/files/the%20fonts/final/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.