### PR TITLE
Update font-dejavu-sans to 2.37

### DIFF
--- a/Casks/font-dejavu-sans.rb
+++ b/Casks/font-dejavu-sans.rb
@@ -3,6 +3,8 @@ cask 'font-dejavu-sans' do
   sha256 '7576310b219e04159d35ff61dd4a4ec4cdba4f35c00e002a136f00e96a908b0a'
 
   url "https://downloads.sourceforge.net/dejavu/dejavu-fonts-ttf-#{version}.zip"
+  appcast 'https://sourceforge.net/projects/dejavu/rss',
+          checkpoint: 'bc0b3295dee28550f9c2e5d71d5394a9afdddb0a9186db2790b260ae57fdc83a'
   name 'DejaVu'
   homepage 'https://sourceforge.net/projects/dejavu/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.