### PR TITLE
Update font-impact to 2.35

### DIFF
--- a/Casks/font-impact.rb
+++ b/Casks/font-impact.rb
@@ -3,6 +3,8 @@ cask 'font-impact' do
   sha256 '6061ef3b7401d9642f5dfdb5f2b376aa14663f6275e60a51207ad4facf2fccfb'
 
   url 'https://downloads.sourceforge.net/corefonts/impact32.exe'
+  appcast 'https://sourceforge.net/projects/corefonts/rss',
+          checkpoint: '8d659740c2893218b3e1d16918a9372b2838f5e0e7ef0405d3103f2d563e7bd1'
   name 'Impact'
   homepage 'http://sourceforge.net/projects/corefonts/files/the%20fonts/final/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.