### PR TITLE
Update font-inconsolata-nerd-font-mono to 1.0.0

### DIFF
--- a/Casks/font-inconsolata-nerd-font-mono.rb
+++ b/Casks/font-inconsolata-nerd-font-mono.rb
@@ -4,7 +4,7 @@ cask 'font-inconsolata-nerd-font-mono' do
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Inconsolata.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '5677b051ebf92449af603ba6f1837c1bba529a881fd41fe0ec5dea830e1f7867'
+          checkpoint: '034cdfeb4f6a152086231f8388940cd9de7d8190aecbb26ec94e7a381bf7a3b7'
   name 'InconsolataForPowerline Nerd Font (Inconsolata)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.