### PR TITLE
Update font-devicons to 1.8.0

### DIFF
--- a/Casks/font-devicons.rb
+++ b/Casks/font-devicons.rb
@@ -1,11 +1,11 @@
 cask 'font-devicons' do
-  version '1.7.0'
-  sha256 '13d98f9aa064e5c2a8f03721c455f01a21cb6879562dca03b8a2a608b292ecf2'
+  version '1.8.0'
+  sha256 'fc0baa260f54832c059d1d9eab3798ae758d1a1cf0c1695e9883aab85d9a4308'
 
   # github.com/vorillaz/devicons was verified as official when first introduced to the cask
   url "https://github.com/vorillaz/devicons/archive/#{version}.zip"
   appcast 'https://github.com/vorillaz/devicons/releases.atom',
-          checkpoint: '58348b09a132c426965c2b7291528beace49246da2ac98c447ee58f7f6143da6'
+          checkpoint: '63c8fbe42960d87afed8a74379c6c423861708f28831a82f1ab82df93c4d8112'
   name 'Devicons'
   homepage 'http://vorillaz.github.io/devicons/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.