### PR TITLE
Update font-gandom to 0.5.1

### DIFF
--- a/Casks/font-gandom.rb
+++ b/Casks/font-gandom.rb
@@ -1,11 +1,11 @@
 cask 'font-gandom' do
-  version '0.4.5'
-  sha256 '4ea2ca208312e405252c8b8373b2a1bab1158f3f5388650a1ac89e195a1b42f0'
+  version '0.5.1'
+  sha256 '87fea02baa89524b8cf2873a08c28fddd35dcf3558110c13522328b0cbefaa62'
 
   # github.com/rastikerdar was verified as official when first introduced to the cask
   url "https://github.com/rastikerdar/gandom-font/releases/download/v#{version}/gandom-font-v#{version}.zip"
   appcast 'https://github.com/rastikerdar/gandom-font/releases.atom',
-          checkpoint: 'ad2a2478a782726dd4f8629cff19c36f83e3dff204ec3aeafc19ce3feaf9876b'
+          checkpoint: 'c01ed9ef627b04b6798a482ab86fd756e2228cf973fddd4f042146bfc066cbb7'
   name 'Gandom'
   homepage 'http://rastikerdar.github.io/gandom-font'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.