### PR TITLE
Update font-parastoo to 1.0.0-alpha3

### DIFF
--- a/Casks/font-parastoo.rb
+++ b/Casks/font-parastoo.rb
@@ -1,11 +1,11 @@
 cask 'font-parastoo' do
-  version '0.12.1'
-  sha256 '03cd39d8f73698d85a488b37a5edb40750b87e3a9ba6f1e8e17d1ee1198d92f6'
+  version '1.0.0-alpha3'
+  sha256 '7e02a35c0755317f2680a2d5f57cacc2503309a75b28062244ec26fc1a0a162f'
 
   # github.com/rastikerdar was verified as official when first introduced to the cask
   url "https://github.com/rastikerdar/parastoo-font/releases/download/v#{version}/parastoo-font-v#{version}.zip"
   appcast 'https://github.com/rastikerdar/parastoo-font/releases.atom',
-          checkpoint: '460686441568187829d4158fca2066320da3d2dc37743dc9bfa490201f3bf902'
+          checkpoint: '0cdbdf8250e744f6cca84ab68b04f28e7031924f363f80b09babea4de84e6af7'
   name 'Parastoo'
   homepage 'http://rastikerdar.github.io/parastoo-font'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.