### PR TITLE
Update font-vazir to 10.0.0-beta

### DIFF
--- a/Casks/font-vazir.rb
+++ b/Casks/font-vazir.rb
@@ -1,11 +1,11 @@
 cask 'font-vazir' do
-  version '6.3.3'
-  sha256 '6464e116f71df112a152ccc9037947f2904e0741206913ed229199b0cc0aad07'
+  version '10.0.0-beta'
+  sha256 '117351354399015132ff2993ebb769600d889e0a9bbf16e7ea456996a85c8d47'
 
   # github.com/rastikerdar was verified as official when first introduced to the cask
   url "https://github.com/rastikerdar/vazir-font/releases/download/v#{version}/vazir-font-v#{version}.zip"
   appcast 'https://github.com/rastikerdar/vazir-font/releases.atom',
-          checkpoint: 'e1fc4d465d0abb76653bbc0a3766ff064bf071acb93c190c0dd60b4e6586a7cb'
+          checkpoint: '356523aaaf06bab31561115ba0189258b7e8c1f5721f92f424d620cd49adf14f'
   name 'Vazir'
   homepage 'https://rastikerdar.github.io/vazir-font/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.