### PR TITLE
Update font-vazir-code to 1.0.3

### DIFF
--- a/Casks/font-vazir-code.rb
+++ b/Casks/font-vazir-code.rb
@@ -1,11 +1,11 @@
 cask 'font-vazir-code' do
-  version '1.0.2'
-  sha256 '818ac08a491cab9f2f521ddf4bff0a92b249e2fbc0aa141d9479608d002b0028'
+  version '1.0.3'
+  sha256 '8a0bcc3e0ab9f086aeb3d8d2827825dc5b582f34562ad4c0b6f79242a692249a'
 
   # github.com/rastikerdar was verified as official when first introduced to the cask
   url "https://github.com/rastikerdar/vazir-code-font/releases/download/v#{version}/vazir-code-font-v#{version}.zip"
   appcast 'https://github.com/rastikerdar/vazir-code-font/releases.atom',
-          checkpoint: '1ebc829b79c2da30cd4ca267e3d61a96e6fd396d6daa0def751b5379943a5ee5'
+          checkpoint: '6dc9f4c0b247ffeb83163a4b2c20f56177a1afe8f04315315e53bfe9f30d4f70'
   name 'Vazir Code'
   homepage 'https://rastikerdar.github.io/vazir-code-font/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.