### PR TITLE
Update font-source-han-serif-el-m to 1.001R

### DIFF
--- a/Casks/font-source-han-serif-el-m.rb
+++ b/Casks/font-source-han-serif-el-m.rb
@@ -1,10 +1,10 @@
 cask 'font-source-han-serif-el-m' do
-  version '1.000'
-  sha256 '175b3ffe8a936917c59139dcbea0b45632203f0bec5d5651c17ec0c545b540bf'
+  version '1.001R'
+  sha256 '3d23f70a6d134fd4206a920c4d54376f2b68393beabf60af1d56a451d03eae26'
 
   url 'https://github.com/adobe-fonts/source-han-serif/raw/release/OTC/SourceHanSerifOTC_EL-M.zip'
   appcast 'https://github.com/adobe-fonts/source-han-serif/releases.atom',
-          checkpoint: 'dafebca50a7068ffd66e74811b7de9214aaa369ff30898e5257a06f3340a2244'
+          checkpoint: '47de4f7140b72957ecb8063853cecc20533fea5f9fd280a1b70da851348690e5'
   name 'Source Han Serif EL-M'
   homepage 'https://github.com/adobe-fonts/source-han-serif'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.