### PR TITLE
Update font-source-han-serif-sb-h to 1.001R

### DIFF
--- a/Casks/font-source-han-serif-sb-h.rb
+++ b/Casks/font-source-han-serif-sb-h.rb
@@ -1,10 +1,10 @@
 cask 'font-source-han-serif-sb-h' do
-  version '1.000'
-  sha256 '1ed9599cecb4f1290d52a6d29f84a3560a89515675102b2b561d5406621a803b'
+  version '1.001R'
+  sha256 'e7c7c0c02e43f7cc6b1dd54e5e3a313b434123a796c8b64459f95174a6021645'
 
   url 'https://github.com/adobe-fonts/source-han-serif/raw/release/OTC/SourceHanSerifOTC_SB-H.zip'
   appcast 'https://github.com/adobe-fonts/source-han-serif/releases.atom',
-          checkpoint: 'dafebca50a7068ffd66e74811b7de9214aaa369ff30898e5257a06f3340a2244'
+          checkpoint: '47de4f7140b72957ecb8063853cecc20533fea5f9fd280a1b70da851348690e5'
   name 'Source Han Serif SB-H'
   homepage 'https://github.com/adobe-fonts/source-han-serif'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.