### PR TITLE
Update Gentium family upstream URL's and versions

### DIFF
--- a/Casks/font-gentium-basic.rb
+++ b/Casks/font-gentium-basic.rb
@@ -1,17 +1,13 @@
 cask 'font-gentium-basic' do
-  version :latest
-  sha256 :no_check
+  version '1.102'
+  sha256 '2f1a2c5491d7305dffd3520c6375d2f3e14931ee35c6d8ae1e8f098bf1a7b3cc'
 
-  # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/trunk/ofl/gentiumbasic',
-      using:      :svn,
-      revision:   '50',
-      trust_cert: true
+  url "http://software.sil.org/downloads/r/gentium/GentiumBasic_1102.zip"
   name 'Gentium Basic'
-  homepage 'http://www.google.com/fonts/specimen/Gentium%20Basic'
+  homepage 'http://software.sil.org/gentium/'
 
-  font 'GenBasB.ttf'
-  font 'GenBasBI.ttf'
-  font 'GenBasI.ttf'
-  font 'GenBasR.ttf'
+  font 'GentiumBasic_1102/GenBasB.ttf'
+  font 'GentiumBasic_1102/GenBasBI.ttf'
+  font 'GentiumBasic_1102/GenBasI.ttf'
+  font 'GentiumBasic_1102/GenBasR.ttf'
 end

--- a/Casks/font-gentium-basic.rb
+++ b/Casks/font-gentium-basic.rb
@@ -2,12 +2,12 @@ cask 'font-gentium-basic' do
   version '1.102'
   sha256 '2f1a2c5491d7305dffd3520c6375d2f3e14931ee35c6d8ae1e8f098bf1a7b3cc'
 
-  url "http://software.sil.org/downloads/r/gentium/GentiumBasic_1102.zip"
+  url "http://software.sil.org/downloads/r/gentium/GentiumBasic_#{version.no_dots}.zip"
   name 'Gentium Basic'
   homepage 'http://software.sil.org/gentium/'
 
-  font 'GentiumBasic_1102/GenBasB.ttf'
-  font 'GentiumBasic_1102/GenBasBI.ttf'
-  font 'GentiumBasic_1102/GenBasI.ttf'
-  font 'GentiumBasic_1102/GenBasR.ttf'
+  font "GentiumBasic_#{version.no_dots}/GenBasB.ttf"
+  font "GentiumBasic_#{version.no_dots}/GenBasBI.ttf"
+  font "GentiumBasic_#{version.no_dots}/GenBasI.ttf"
+  font "GentiumBasic_#{version.no_dots}/GenBasR.ttf"
 end

--- a/Casks/font-gentium-book-basic.rb
+++ b/Casks/font-gentium-book-basic.rb
@@ -2,12 +2,12 @@ cask 'font-gentium-book-basic' do
   version '1.102'
   sha256 '2f1a2c5491d7305dffd3520c6375d2f3e14931ee35c6d8ae1e8f098bf1a7b3cc'
 
-  url "http://software.sil.org/downloads/r/gentium/GentiumBasic_1102.zip"
+  url "http://software.sil.org/downloads/r/gentium/GentiumBasic_#{version.no_dots}.zip"
   name 'Gentium Book Basic'
   homepage 'http://software.sil.org/gentium/'
 
-  font 'GentiumBasic_1102/GenBkBasB.ttf'
-  font 'GentiumBasic_1102/GenBkBasBI.ttf'
-  font 'GentiumBasic_1102/GenBkBasI.ttf'
-  font 'GentiumBasic_1102/GenBkBasR.ttf'
+  font "GentiumBasic_#{version.no_dots}/GenBkBasB.ttf"
+  font "GentiumBasic_#{version.no_dots}/GenBkBasBI.ttf"
+  font "GentiumBasic_#{version.no_dots}/GenBkBasI.ttf"
+  font "GentiumBasic_#{version.no_dots}/GenBkBasR.ttf"
 end

--- a/Casks/font-gentium-book-basic.rb
+++ b/Casks/font-gentium-book-basic.rb
@@ -1,17 +1,13 @@
 cask 'font-gentium-book-basic' do
-  version :latest
-  sha256 :no_check
+  version '1.102'
+  sha256 '2f1a2c5491d7305dffd3520c6375d2f3e14931ee35c6d8ae1e8f098bf1a7b3cc'
 
-  # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/trunk/ofl/gentiumbookbasic',
-      using:      :svn,
-      revision:   '50',
-      trust_cert: true
+  url "http://software.sil.org/downloads/r/gentium/GentiumBasic_1102.zip"
   name 'Gentium Book Basic'
-  homepage 'http://www.google.com/fonts/specimen/Gentium%20Book%20Basic'
+  homepage 'http://software.sil.org/gentium/'
 
-  font 'GenBkBasB.ttf'
-  font 'GenBkBasBI.ttf'
-  font 'GenBkBasI.ttf'
-  font 'GenBkBasR.ttf'
+  font 'GentiumBasic_1102/GenBkBasB.ttf'
+  font 'GentiumBasic_1102/GenBkBasBI.ttf'
+  font 'GentiumBasic_1102/GenBkBasI.ttf'
+  font 'GentiumBasic_1102/GenBkBasR.ttf'
 end


### PR DESCRIPTION
Google fonts is not the official (or most up to date) release channel for the Gentium font family. This updates the 3 fonts in the family with the correct upstream location.

Note I am unable to run the brew  checks because I do not currently have access to a working Mac.

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.