### PR TITLE
Update font-ionicons to 2.0.1

### DIFF
--- a/Casks/font-ionicons.rb
+++ b/Casks/font-ionicons.rb
@@ -2,11 +2,11 @@ cask 'font-ionicons' do
   version '2.0.1'
   sha256 'b222fcaede908b71d5b206db9fb7b625a07d313be00ee908eabd267604868661'
 
-  url "https://github.com/driftyco/ionicons/archive/v#{version}.zip"
+  url "https://github.com/ionic-team/ionicons/archive/v#{version}.zip"
   appcast 'https://github.com/ionic-team/ionicons/releases.atom',
           checkpoint: 'fc4c879e72002442cb2e7ba738b886070c4c8409148b5b3c74dc0a043343730d'
   name 'Ionicons'
-  homepage 'https://github.com/driftyco/ionicons'
+  homepage 'https://github.com/ionic-team/ionicons'
 
   font "ionicons-#{version}/fonts/ionicons.ttf"
 end

--- a/Casks/font-ionicons.rb
+++ b/Casks/font-ionicons.rb
@@ -3,8 +3,8 @@ cask 'font-ionicons' do
   sha256 'b222fcaede908b71d5b206db9fb7b625a07d313be00ee908eabd267604868661'
 
   url "https://github.com/driftyco/ionicons/archive/v#{version}.zip"
-  appcast 'https://github.com/driftyco/ionicons/releases.atom',
-          checkpoint: '3b4af4ca1eb9b498b480c6f6a0fb39f25d7f70538d720110e758c18dd10a1b0a'
+  appcast 'https://github.com/ionic-team/ionicons/releases.atom',
+          checkpoint: 'fc4c879e72002442cb2e7ba738b886070c4c8409148b5b3c74dc0a043343730d'
   name 'Ionicons'
   homepage 'https://github.com/driftyco/ionicons'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}