### PR TITLE
Update font-vazir to 11.0.1

### DIFF
--- a/Casks/font-vazir.rb
+++ b/Casks/font-vazir.rb
@@ -1,11 +1,11 @@
 cask 'font-vazir' do
-  version '10.0.0-beta'
-  sha256 '117351354399015132ff2993ebb769600d889e0a9bbf16e7ea456996a85c8d47'
+  version '11.0.1'
+  sha256 '4181de7939e24d2fadedd92faadd25971e0af9076fa569125c2079cf1b28dd93'
 
   # github.com/rastikerdar was verified as official when first introduced to the cask
   url "https://github.com/rastikerdar/vazir-font/releases/download/v#{version}/vazir-font-v#{version}.zip"
   appcast 'https://github.com/rastikerdar/vazir-font/releases.atom',
-          checkpoint: '356523aaaf06bab31561115ba0189258b7e8c1f5721f92f424d620cd49adf14f'
+          checkpoint: '0e5df32d86a95a8e9222be11ef5d01289f15403258bbf068a43d14724c9ccbb5'
   name 'Vazir'
   homepage 'https://rastikerdar.github.io/vazir-font/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}