### PR TITLE
Update font-fantasque-sans-mono to 1.7.1

### DIFF
--- a/Casks/font-fantasque-sans-mono.rb
+++ b/Casks/font-fantasque-sans-mono.rb
@@ -4,7 +4,7 @@ cask 'font-fantasque-sans-mono' do
 
   url "https://github.com/belluzj/fantasque-sans/releases/download/v#{version}/FantasqueSansMono.zip"
   appcast 'https://github.com/belluzj/fantasque-sans/releases.atom',
-          checkpoint: 'c2194a85e1a4985ebb6b40f0ed2564fd47f8c933348ae3d02cb7e06071eda6bc'
+          checkpoint: 'ad0c508b0cf280b5e16618b64299a19c628eabf7c6f470262ba9b8c244463864'
   name 'Fantasque Sans Mono'
   homepage 'https://github.com/belluzj/fantasque-sans'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] [If the `sha256` changed but the `version` didn’t](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256),
      provide public confirmation by the developer: {{link}}