### PR TITLE
Update font-3270-nerd-font to 1.1.0

### DIFF
--- a/Casks/font-3270-nerd-font.rb
+++ b/Casks/font-3270-nerd-font.rb
@@ -1,10 +1,10 @@
 cask 'font-3270-nerd-font' do
-  version '1.0.0'
-  sha256 '494d439bb1ba1c2a22527937b14ceb7a54843a2ca60cdca7b0613ca68bd80591'
+  version '1.1.0'
+  sha256 'a462873fb52827b99da63d5d8ea0ceb46276d3204782fd2417d8c469746da153'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/3270.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name '3270Medium Nerd Font (3270)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}