### PR TITLE
Update font-aurulentsansmono-nerd-font to 1.1.0

### DIFF
--- a/Casks/font-aurulentsansmono-nerd-font.rb
+++ b/Casks/font-aurulentsansmono-nerd-font.rb
@@ -1,10 +1,10 @@
 cask 'font-aurulentsansmono-nerd-font' do
-  version '1.0.0'
-  sha256 '322e758c3783c307e107ca295c3c51abd04cc8f4aaa7c28445038ccab7bb2503'
+  version '1.1.0'
+  sha256 '302c417aa3caaae553ddcd7f4482ea568a4996189623f740a6a87883bd5c5457'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/AurulentSansMono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'AurulentSansMono Nerd Font (AurulentSansMono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}