### PR TITLE
Update font-bitstreamverasansmono-nerd-font to 1.1.0

### DIFF
--- a/Casks/font-bitstreamverasansmono-nerd-font.rb
+++ b/Casks/font-bitstreamverasansmono-nerd-font.rb
@@ -1,10 +1,10 @@
 cask 'font-bitstreamverasansmono-nerd-font' do
-  version '1.0.0'
-  sha256 '3bda2c91fa310646255ce8e143e108e517f7569c3e16689fa1a92db4f6655e97'
+  version '1.1.0'
+  sha256 'e984c2c1e9971555c061b95c8c247c391cb3c0795346d8a56e2f36790e62ac44'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/BitstreamVeraSansMono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'BitstreamVeraSansMono Nerd Font (BitstreamVeraSansMono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}