### PR TITLE
Update font-codenewroman-nerd-font to 1.1.0

### DIFF
--- a/Casks/font-codenewroman-nerd-font.rb
+++ b/Casks/font-codenewroman-nerd-font.rb
@@ -1,10 +1,10 @@
 cask 'font-codenewroman-nerd-font' do
-  version '1.0.0'
-  sha256 '70d26f71f6d336733218989db2170ededdbb5c5248628b1303c26d6a3dc7fba6'
+  version '1.1.0'
+  sha256 '04495de7301c44dad34490704f6eae51f7e9f775b3b84f6537dc7728462929ba'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/CodeNewRoman.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'CodeNewRoman Nerd Font (CodeNewRoman)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}