### PR TITLE
Update font-firamono-nerd-font to 1.1.0

### DIFF
--- a/Casks/font-firamono-nerd-font.rb
+++ b/Casks/font-firamono-nerd-font.rb
@@ -1,10 +1,10 @@
 cask 'font-firamono-nerd-font' do
-  version '1.0.0'
-  sha256 '7b15da1e39e1f1551a40c9847ccaa2c510361b44a99ba363f0f016df82a24720'
+  version '1.1.0'
+  sha256 'c2b5f1928e79ff5738b1aacf8642c68abd3bc5d4ae2db86aa9ac52e7cd2cd25e'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/FiraMono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'FuraMonoForPowerline Nerd Font (FiraMono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}