### PR TITLE
Update font-hermit-nerd-font to 1.1.0

### DIFF
--- a/Casks/font-hermit-nerd-font.rb
+++ b/Casks/font-hermit-nerd-font.rb
@@ -1,10 +1,10 @@
 cask 'font-hermit-nerd-font' do
-  version '1.0.0'
-  sha256 '0c210b23be193b2168f4275218debe0d6c600ce845ec135791c7e19790040031'
+  version '1.1.0'
+  sha256 'aef8e5496298b986b5a6be8ef0408652f6ed2fa0868a8c44f4be79f6d0c16e36'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Hermit.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'Hurmit Nerd Font (Hermit)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}