### PR TITLE
Update font-liberationmono-nerd-font to 1.1.0

### DIFF
--- a/Casks/font-liberationmono-nerd-font.rb
+++ b/Casks/font-liberationmono-nerd-font.rb
@@ -1,10 +1,10 @@
 cask 'font-liberationmono-nerd-font' do
-  version '1.0.0'
-  sha256 '1ecfc29d4ce3e731571ac196d88f4bdfb2297c9626b04c36b66bc4ef80708dc5'
+  version '1.1.0'
+  sha256 '3894056c0825a3dde3ee9a7ee65bff5a44b936b60eaebf4a374b0d26ba55dc9e'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/LiberationMono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'LiterationMonoPowerline Nerd Font (LiberationMono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}