### PR TITLE
Update font-monofur-nerd-font to 1.1.0

### DIFF
--- a/Casks/font-monofur-nerd-font.rb
+++ b/Casks/font-monofur-nerd-font.rb
@@ -1,10 +1,10 @@
 cask 'font-monofur-nerd-font' do
-  version '1.0.0'
-  sha256 'a27a19195f3d648dce2f0a60cad826910d0c763f4001766379bb37bfdd94f49a'
+  version '1.1.0'
+  sha256 '0c9944fc8dd35b868350a668440929aee8f2cea35e295986d172c3b9f7fecadc'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Monofur.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'MonofurboldForPowerline Nerd Font (Monofur)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}