### PR TITLE
Update font-sharetechmono-nerd-font to 1.1.0

### DIFF
--- a/Casks/font-sharetechmono-nerd-font.rb
+++ b/Casks/font-sharetechmono-nerd-font.rb
@@ -1,10 +1,10 @@
 cask 'font-sharetechmono-nerd-font' do
-  version '1.0.0'
-  sha256 '025132812e5e3d6e9b7d53fbbeda0d7e30ec8b50702f1d3aed301d0871e680ec'
+  version '1.1.0'
+  sha256 '47e6b2a728457e47f449bc114c663c67273e2bba323d0163c38e53fb815835d6'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/ShareTechMono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'ShureTechMono Nerd Font (ShareTechMono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] If the `sha256` changed but the `version` didn’t,
      provide public confirmation ([How?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)): {{link}}