### PR TITLE
Update font-press-start2p to 3.000

### DIFF
--- a/Casks/font-press-start2p.rb
+++ b/Casks/font-press-start2p.rb
@@ -4,7 +4,7 @@ cask 'font-press-start2p' do
 
   # github.com/google/fonts was verified as official when first introduced to the cask
   url 'https://github.com/google/fonts/raw/master/ofl/pressstart2p/PressStart2P-Regular.ttf'
-  name 'Press+Start+2P'
+  name 'Press Start 2P'
   homepage 'http://www.google.com/fonts/specimen/Press+Start+2P'
 
   font 'PressStart2P-Regular.ttf'

--- a/Casks/font-press-start2p.rb
+++ b/Casks/font-press-start2p.rb
@@ -1,6 +1,6 @@
 cask 'font-press-start2p' do
-  version '3.000'
-  sha256 '034c77f1f05ec89421e4a63f0e3a4ca1ecf852cc6d2bf611f126f275728e017d'
+  version :latest
+  sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
   url 'https://github.com/google/fonts/raw/master/ofl/pressstart2p/PressStart2P-Regular.ttf'

--- a/Casks/font-press-start2p.rb
+++ b/Casks/font-press-start2p.rb
@@ -1,9 +1,9 @@
 cask 'font-press-start2p' do
-  version '2.14'
-  sha256 '17ec7d250ff590971a6d966b4fdc5aa04d5e39a7694f4a0becb515b6a70a7228'
+  version '3.000'
+  sha256 '034c77f1f05ec89421e4a63f0e3a4ca1ecf852cc6d2bf611f126f275728e017d'
 
   # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://raw.github.com/google/fonts/master/ofl/pressstart2p/PressStart2P-Regular.ttf'
+  url 'https://github.com/google/fonts/raw/master/ofl/pressstart2p/PressStart2P-Regular.ttf'
   name 'Press+Start+2P'
   homepage 'http://www.google.com/fonts/specimen/Press+Start+2P'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.