### PR TITLE
Update font-interface to 1.6

### DIFF
--- a/Casks/font-interface.rb
+++ b/Casks/font-interface.rb
@@ -1,14 +1,16 @@
 cask 'font-interface' do
-  version '1.5'
-  sha256 '0fef95f3c54eafabefbf049432561c24a5c9e9f23a343c9313c17db5018e76c9'
+  version '1.6'
+  sha256 'd22c4931d7e4f4dff5705304f72a68e77287e861c7ca0c0071a205d7f9455c67'
 
   # github.com/rsms/interface was verified as official when first introduced to the cask
   url "https://github.com/rsms/interface/releases/download/v#{version}/Interface-#{version}.zip"
   appcast 'https://github.com/rsms/interface/releases.atom',
-          checkpoint: '60f56483451ab9412a1d47f2ba6a546c98fd2e1304351c46ef209ad60aa16c61'
+          checkpoint: '33a185e8f94bcbd4c47afdb63c4af2ed47f5f8a229e42dbac8f9fb2a366790ff'
   name 'Interface'
   homepage 'https://rsms.me/interface/'
 
+  font 'Interface (OTF)/Interface-Black.otf'
+  font 'Interface (OTF)/Interface-BlackItalic.otf'
   font 'Interface (OTF)/Interface-Bold.otf'
   font 'Interface (OTF)/Interface-BoldItalic.otf'
   font 'Interface (OTF)/Interface-Medium.otf'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.