### PR TITLE
Update font-anonymouspro-nerd-font-mono to 1.1.0

### DIFF
--- a/Casks/font-anonymouspro-nerd-font-mono.rb
+++ b/Casks/font-anonymouspro-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-anonymouspro-nerd-font-mono' do
-  version '1.0.0'
-  sha256 'dfc5c87d6e119e85c74de8d3cc1df78326538bc60a1cbe5d63a9ef5b58aeca05'
+  version '1.1.0'
+  sha256 'b0ae604f8841c7bf8ab3adb9eba10e702108964240fc817010a2e7c2e9ab2d7a'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/AnonymousPro.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'AnonymicePowerline Nerd Font (AnonymousPro)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.