### PR TITLE
Update font-gohu-nerd-font-mono to 1.1.0

### DIFF
--- a/Casks/font-gohu-nerd-font-mono.rb
+++ b/Casks/font-gohu-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-gohu-nerd-font-mono' do
-  version '1.0.0'
-  sha256 '9e46996100c87c5aaced79f48fddc5ae3d779245ef0b2922d8c8ecb1f3ba02c1'
+  version '1.1.0'
+  sha256 'ad9ca3eeefb0dcca733b31df1f61e944f9428290546a939d8ba3cf70fe4388b6'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Gohu.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'GohuFontBold Nerd Font (Gohu)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.