### PR TITLE
Update font-hack-nerd-font-mono to 1.1.0

### DIFF
--- a/Casks/font-hack-nerd-font-mono.rb
+++ b/Casks/font-hack-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-hack-nerd-font-mono' do
-  version '1.0.0'
-  sha256 '987eadbdaa11c4091a518a7d78c37f5f9bf2279b7c2aa6504907faf23e9673e5'
+  version '1.1.0'
+  sha256 'ceebc8767d79b774b631c56fec1082b008310b0c6e5bb4b8e8826027ec6db882'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Hack.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'Knack Nerd Font (Hack)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.