### PR TITLE
Update font-heavydata-nerd-font-mono to 1.1.0

### DIFF
--- a/Casks/font-heavydata-nerd-font-mono.rb
+++ b/Casks/font-heavydata-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-heavydata-nerd-font-mono' do
-  version '1.0.0'
-  sha256 '9d787fb259ff1a40f4596a39916b9a2a7f2098a6851707c0e495517b6c306c02'
+  version '1.1.0'
+  sha256 '3a1eda8eaa51c7a6e96b73e6c0e73022d1257c2d213398cf7a595686c7445bbd'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/HeavyData.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'HeavyData Nerd Font (HeavyData)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.