### PR TITLE
Update font-lekton-nerd-font-mono to 1.1.0

### DIFF
--- a/Casks/font-lekton-nerd-font-mono.rb
+++ b/Casks/font-lekton-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-lekton-nerd-font-mono' do
-  version '1.0.0'
-  sha256 '8d1aa238c7aaa368c912c9d11a0fd5cac43db023cce6a49472491d823438d07e'
+  version '1.1.0'
+  sha256 '06fdd68a3f68f34004b56291f947480b1da1e0640651d02c40cb65d95497398e'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Lekton.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'Lekton Nerd Font (Lekton)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.