### PR TITLE
Update font-monoid-nerd-font-mono to 1.1.0

### DIFF
--- a/Casks/font-monoid-nerd-font-mono.rb
+++ b/Casks/font-monoid-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-monoid-nerd-font-mono' do
-  version '1.0.0'
-  sha256 '8a0d84174ec3a79cf625bf9cd5e9181470d4d3d627ed88a15abc37ae8c94571f'
+  version '1.1.0'
+  sha256 '6c94c44e7a2d00ff96f9dd4a4f3fd7e89b0227265f177d11bf715fced9639017'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Monoid.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'Monoid Nerd Font (Monoid)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.