### PR TITLE
Update font-mplus-nerd-font-mono to 1.1.0

### DIFF
--- a/Casks/font-mplus-nerd-font-mono.rb
+++ b/Casks/font-mplus-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-mplus-nerd-font-mono' do
-  version '1.0.0'
-  sha256 '102e1bf17dd1962b19d508e76bdb29aef4571e7e18040e9b2561879f3955a82a'
+  version '1.1.0'
+  sha256 '3d5f7cb08eaeb22c256d5c62af807e4ddc66f5d9834590b9abdb0728e08f0125'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/MPlus.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'mplus Nerd Font (MPlus)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.