### PR TITLE
Update font-profont-nerd-font-mono to 1.1.0

### DIFF
--- a/Casks/font-profont-nerd-font-mono.rb
+++ b/Casks/font-profont-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-profont-nerd-font-mono' do
-  version '1.0.0'
-  sha256 '8a6fdd5ffa5473ecb337cb9606cf89b4d26f1454c5722ca19ff7741055fd1ce5'
+  version '1.1.0'
+  sha256 '4463c9f5a4dd1dbd27d198c893819e7552d77e607f33e806e0b916fc506f7694'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/ProFont.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'ProFontIIx Nerd Font (ProFont)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.