### PR TITLE
Update font-sourcecodepro-nerd-font-mono to 1.1.0

### DIFF
--- a/Casks/font-sourcecodepro-nerd-font-mono.rb
+++ b/Casks/font-sourcecodepro-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-sourcecodepro-nerd-font-mono' do
-  version '1.0.0'
-  sha256 '2aa8dc2444f0cd44546c36ab18b0996c8bc7747402b6e17f67ca9acec34f3879'
+  version '1.1.0'
+  sha256 '281a86c503bf6dd5664169aeeb18ec1165f163a79e18909dbea319b8b9667173'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/SourceCodePro.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'SauceCodePro Nerd Font (SourceCodePro)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.