### PR TITLE
Update font-ubuntumono-nerd-font-mono to 1.1.0

### DIFF
--- a/Casks/font-ubuntumono-nerd-font-mono.rb
+++ b/Casks/font-ubuntumono-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-ubuntumono-nerd-font-mono' do
-  version '1.0.0'
-  sha256 '68953e5ffb6f225dd379805c1d50cc010f9b89446a3ec1fce5605b5072bb82de'
+  version '1.1.0'
+  sha256 'fb423fa6f5d1b3143df0200d9c66147d9677bf825d4f49a5c6ea843a278b8f1e'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/UbuntuMono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'dbe84e88af08eb844f7f21de92a1fc57e8df10d3028055aff03e0441598806df'
+          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
   name 'UbuntuMono Nerd Font (UbuntuMono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.