### PR TITLE
Update font-luckiest-guy to latest

### DIFF
--- a/Casks/font-luckiest-guy.rb
+++ b/Casks/font-luckiest-guy.rb
@@ -3,7 +3,7 @@ cask 'font-luckiest-guy' do
   sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/raw/master/apache/luckiestguy/LuckiestGuy.ttf'
+  url 'https://github.com/google/fonts/raw/master/apache/luckiestguy/LuckiestGuy-Regular.ttf'
   name 'Luckiest Guy'
   homepage 'http://www.google.com/fonts/specimen/Luckiest+Guy'
 

--- a/Casks/font-luckiest-guy.rb
+++ b/Casks/font-luckiest-guy.rb
@@ -7,5 +7,5 @@ cask 'font-luckiest-guy' do
   name 'Luckiest Guy'
   homepage 'http://www.google.com/fonts/specimen/Luckiest+Guy'
 
-  font 'LuckiestGuy.ttf'
+  font 'LuckiestGuy-Regular.ttf'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.