### PR TITLE
Update font-xkcd to latest

### DIFF
--- a/Casks/font-xkcd.rb
+++ b/Casks/font-xkcd.rb
@@ -2,7 +2,7 @@ cask 'font-xkcd' do
   version :latest
   sha256 :no_check
 
-  url 'https://github.com/ipython/xkcd-font/raw/master/build/xkcd.otf'
+  url 'https://github.com/ipython/xkcd-font/raw/master/xkcd/build/xkcd.otf'
   name 'xkcd'
   homepage 'https://github.com/ipython/xkcd-font'
 


### PR DESCRIPTION
The location of the font moved into a subfolder (`./build/` ➡️ `./xkcd/build/`).

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
