### PR TITLE
Update font-libra-caslon-text to latest

### DIFF
--- a/Casks/font-libre-caslon-text.rb
+++ b/Casks/font-libre-caslon-text.rb
@@ -2,11 +2,12 @@ cask 'font-libre-caslon-text' do
   version :latest
   sha256 :no_check
 
-  url 'http://www.impallari.com/media/uploads/prosources/update-94-source.zip'
+  # github.com/impallari/Libre-Caslon-Text was verified as official when first introduced to the cask
+  url 'https://github.com/impallari/Libre-Caslon-Text/archive/master.zip'
   name 'Libre Caslon Text'
   homepage 'http://www.impallari.com/projects/overview/libre-caslon-display-and-text'
 
-  font 'Libre Caslon Text v1.0/LibreCaslonText-Bold.ttf'
-  font 'Libre Caslon Text v1.0/LibreCaslonText-Italic.ttf'
-  font 'Libre Caslon Text v1.0/LibreCaslonText-Regular.ttf'
+  font 'Libre-Caslon-Text-master/fonts/OTF/LibreCaslonText-Bold.otf'
+  font 'Libre-Caslon-Text-master/fonts/OTF/LibreCaslonText-Italic.otf'
+  font 'Libre-Caslon-Text-master/fonts/OTF/LibreCaslonText-Regular.otf'
 end


### PR DESCRIPTION
The files are now fetched from github.com/impallari/Libre-Caslon-Test.
According to http://www.impallari.com/projects, all projects are now hosted at GitHub.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [X] `brew cask audit --download {{cask_file}}` is error-free.
- [X] `brew cask style --fix {{cask_file}}` reports no offenses.
- [X] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?][version-checksum]).  
      I’m providing public confirmation below.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
