### PR TITLE
Update font-inter-ui to 1.11

### DIFF
--- a/Casks/font-inter-ui.rb
+++ b/Casks/font-inter-ui.rb
@@ -1,11 +1,11 @@
 cask 'font-inter-ui' do
   version '1.11'
-  sha256 'a9dd5f8430621e518a009cc5b1f2137d72fde570fe12197e92fdac0723ece239'
+  sha256 'cdef15906954f45f8a6792c1fa01faf8889d7e70c7d0b2ef7da6c356672d48b8'
 
   # github.com/rsms/inter was verified as official when first introduced to the cask
   url "https://github.com/rsms/inter/releases/download/v#{version}/Inter-UI-#{version}.zip"
   appcast 'https://github.com/rsms/inter/releases.atom',
-          checkpoint: '2cffd4efea6fff77a20bc07a52e1f51c117356ca89bf2e035c4c83f372d901a9'
+          checkpoint: '0db9134148b3d79e467bc5ffa4eb2596e3d04db0b012fa04edb88a249a14ec24'
   name 'Inter UI'
   homepage 'https://rsms.me/inter/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.