### PR TITLE
Update font-inter-ui to 2.0

### DIFF
--- a/Casks/font-inter-ui.rb
+++ b/Casks/font-inter-ui.rb
@@ -1,11 +1,11 @@
 cask 'font-inter-ui' do
-  version '1.11'
-  sha256 'a9dd5f8430621e518a009cc5b1f2137d72fde570fe12197e92fdac0723ece239'
+  version '2.0'
+  sha256 '2690866d0aa4460e332dbe10c1b7117b5ca1dd770c65a4c2b073494b4d618836'
 
   # github.com/rsms/inter was verified as official when first introduced to the cask
   url "https://github.com/rsms/inter/releases/download/v#{version}/Inter-UI-#{version}.zip"
   appcast 'https://github.com/rsms/inter/releases.atom',
-          checkpoint: '2cffd4efea6fff77a20bc07a52e1f51c117356ca89bf2e035c4c83f372d901a9'
+          checkpoint: '125d0bbe99772c73e2728709ea0da65b27a94adaddd381d13e9d5734e33f4ed6'
   name 'Inter UI'
   homepage 'https://rsms.me/inter/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.