### PR TITLE
Update font-inter-ui to 2.1

### DIFF
--- a/Casks/font-inter-ui.rb
+++ b/Casks/font-inter-ui.rb
@@ -1,11 +1,11 @@
 cask 'font-inter-ui' do
-  version '2.0'
-  sha256 '2690866d0aa4460e332dbe10c1b7117b5ca1dd770c65a4c2b073494b4d618836'
+  version '2.1'
+  sha256 '81d9ca2c73eea3df320f42239e66272b5b33a728af7f568e51afc35c15437eed'
 
   # github.com/rsms/inter was verified as official when first introduced to the cask
   url "https://github.com/rsms/inter/releases/download/v#{version}/Inter-UI-#{version}.zip"
   appcast 'https://github.com/rsms/inter/releases.atom',
-          checkpoint: '125d0bbe99772c73e2728709ea0da65b27a94adaddd381d13e9d5734e33f4ed6'
+          checkpoint: 'a1f418970b7a614152c367beea034db113dd27c9195262d072688e91f74589d0'
   name 'Inter UI'
   homepage 'https://rsms.me/inter/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] **I verified this change is legitimate**<sup>[how do I do that?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)</sup>. I did so because `sha256` was altered, but `version` was not. I’m providing confirmation below, [as instructed by the guide](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256).