### PR TITLE
Update font-ultra filename and URL

### DIFF
--- a/Casks/font-ultra.rb
+++ b/Casks/font-ultra.rb
@@ -3,9 +3,9 @@ cask 'font-ultra' do
   sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/raw/master/apache/ultra/Ultra.ttf'
+  url 'https://github.com/google/fonts/raw/master/apache/ultra/Ultra-Regular.ttf'
   name 'Ultra'
   homepage 'http://www.google.com/fonts/specimen/Ultra'
 
-  font 'Ultra.ttf'
+  font 'Ultra-Regular.ttf'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

It seems that the new version is 1.001 but due that this font is not versioned and it's hosted on github I think that it's better to reflect the filename and URL update instead of the version. If you prefer to show the font version I can update the message to include it.