### PR TITLE
Update font-et-book to latest

### DIFF
--- a/Casks/font-et-book.rb
+++ b/Casks/font-et-book.rb
@@ -3,7 +3,7 @@ cask 'font-et-book' do
   sha256 :no_check
 
   # github.com/edwardtufte/et-book was verified as official when first introduced to the cask
-  url 'https://github.com/edwardtufte/et-book/trunk/et-book',
+  url 'http://edwardtufte.github.io/et-book/et-book',
       using:      :svn,
       revision:   '50',
       trust_cert: true


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **updating a cask**:

- [ ] `sha256` changed but `version` stayed the same ([what is this?](https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256)).
      I’m providing public confirmation below.