### PR TITLE
Update font-special-elite filename and download URL

### DIFF
--- a/Casks/font-special-elite.rb
+++ b/Casks/font-special-elite.rb
@@ -3,9 +3,9 @@ cask 'font-special-elite' do
   sha256 :no_check
 
   # github.com/google/fonts was verified as official when first introduced to the cask
-  url 'https://github.com/google/fonts/raw/master/apache/specialelite/SpecialElite.ttf'
+  url 'https://github.com/google/fonts/raw/master/apache/specialelite/SpecialElite-Regular.ttf'
   name 'Special Elite'
   homepage 'http://www.google.com/fonts/specimen/Special+Elite'
 
-  font 'SpecialElite.ttf'
+  font 'SpecialElite-Regular.ttf'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

Due that this font is not versioned and it's hosted on github I think that it's better to reflect the filename and URL update instead of the version. If you prefer to show the font version I can update the message to include it.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
