### PR TITLE
squiggly heredocs

### DIFF
--- a/Casks/font-input.rb
+++ b/Casks/font-input.rb
@@ -178,11 +178,10 @@ cask 'font-input' do
   font 'Input_Fonts/InputSerif/InputSerifNarrow/InputSerifNarrow-ThinItalic.ttf'
 
   caveats do
-    <<-EOS.undent
-    To use the Input fonts, you must agree to the terms of the license.
+    <<~EOS
+      To use the Input fonts, you must agree to the terms of the license.
 
-    #{caskroom_path}/#{version}/LICENSE.txt
-    http://input.fontbureau.com/license/
+        http://input.fontbureau.com/license/
     EOS
   end
 end

--- a/Casks/font-monoid.rb
+++ b/Casks/font-monoid.rb
@@ -14,7 +14,7 @@ cask 'font-monoid' do
   font 'Monoid-Regular.ttf'
   font 'Monoid-Retina.ttf'
 
-  caveats <<-EOS.undent
+  caveats <<~EOS
     #{token} only installs the Normal Weight, Medium LineHeight, with Ligatures variant.
     To get other styles, please tap the sscotth/homebrew-monoid repo
       brew tap sscotth/monoid

--- a/Casks/font-source-han-serif-el-m.rb
+++ b/Casks/font-source-han-serif-el-m.rb
@@ -13,7 +13,7 @@ cask 'font-source-han-serif-el-m' do
   font 'SourceHanSerifOTC_EL-M/SourceHanSerif-Medium.ttc'
   font 'SourceHanSerifOTC_EL-M/SourceHanSerif-Regular.ttc'
 
-  caveats <<-EOS.undent
+  caveats <<~EOS
     #{token} only installs the ExtraLight, Light, Regular and Medium weights.
     To install SemiBold, Bold, and Heavy:
 

--- a/Casks/font-source-han-serif-sb-h.rb
+++ b/Casks/font-source-han-serif-sb-h.rb
@@ -12,7 +12,7 @@ cask 'font-source-han-serif-sb-h' do
   font 'SourceHanSerifOTC_SB-H/SourceHanSerif-Bold.ttc'
   font 'SourceHanSerifOTC_SB-H/SourceHanSerif-Heavy.ttc'
 
-  caveats <<-EOS.undent
+  caveats <<~EOS
     #{token} only installs the SemiBold, Bold, and Heavy weights.
     To install ExtraLight, Light, Regular, and Medium:
 


### PR DESCRIPTION
For `font-input` the license caveat points to the `url` only, which is in the same style as the other Casks with license `caveats`

https://github.com/caskroom/homebrew-cask/pull/39869