### PR TITLE
Update font-vazir to 16.1.0

### DIFF
--- a/Casks/font-vazir.rb
+++ b/Casks/font-vazir.rb
@@ -1,11 +1,11 @@
 cask 'font-vazir' do
-  version '13.0.1'
-  sha256 '00dee07c4ec18d250c2d8196913ec92df2298b5c5b5d155645ee37a0cf71226d'
+  version '16.1.0'
+  sha256 'acd48aafe25b0b3f740b9136d7f4f73a184743d61c593016a3e34c92fabdc0a5'
 
   # github.com/rastikerdar was verified as official when first introduced to the cask
   url "https://github.com/rastikerdar/vazir-font/releases/download/v#{version}/vazir-font-v#{version}.zip"
   appcast 'https://github.com/rastikerdar/vazir-font/releases.atom',
-          checkpoint: '9ea805b022057c745846d95d5bd9216933cd1d8d6d505643f38e1351e82c0a9f'
+          checkpoint: 'bcc7b58994b2c1fc4b2c560fac949e24c3771d32fe48a7f21a516a966946776b'
   name 'Vazir'
   homepage 'https://rastikerdar.github.io/vazir-font/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.