### PR TITLE
Update font-d2coding to 1.3,Ver1.3-20171129

### DIFF
--- a/Casks/font-d2coding.rb
+++ b/Casks/font-d2coding.rb
@@ -3,6 +3,8 @@ cask 'font-d2coding' do
   sha256 '3be175e6969852c6e7501c0a1afa387a6ac845e583c5c2510fa069551e567cdd'
 
   url "https://github.com/naver/d2codingfont/releases/download/VER#{version.before_comma}/D2Coding-#{version.after_comma}.zip"
+  appcast 'https://github.com/naver/d2codingfont/releases.atom',
+          checkpoint: '63d857249403dd983c2a79e390f9f4c0b7706eded063d834d5daad7c5d801c50'
   name 'D2 Coding'
   homepage 'https://github.com/naver/d2codingfont'
 

--- a/Casks/font-d2coding.rb
+++ b/Casks/font-d2coding.rb
@@ -8,5 +8,5 @@ cask 'font-d2coding' do
   name 'D2 Coding'
   homepage 'https://github.com/naver/d2codingfont'
 
-  font 'D2Coding.ttc'
+  font "D2Coding-#{version.after_comma}/D2Coding-#{version.after_comma}.ttc"
 end

--- a/Casks/font-d2coding.rb
+++ b/Casks/font-d2coding.rb
@@ -1,6 +1,6 @@
 cask 'font-d2coding' do
-  version '1.21,1.2'
-  sha256 '788dfd603665ad48b69b8b81ef00ab804edb1b249d58788c6741b25b3625f46a'
+  version '1.3,Ver1.3-20171129'
+  sha256 '3be175e6969852c6e7501c0a1afa387a6ac845e583c5c2510fa069551e567cdd'
 
   url "https://github.com/naver/d2codingfont/releases/download/VER#{version.before_comma}/D2Coding-#{version.after_comma}.zip"
   name 'D2 Coding'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.