### PR TITLE
Update Ubuntu's download link

### DIFF
--- a/Casks/font-ubuntu.rb
+++ b/Casks/font-ubuntu.rb
@@ -1,22 +1,22 @@
 cask 'font-ubuntu' do
-  version '0.83'
+  version '0.83,fad7939b'
   sha256 '456d7d42797febd0d7d4cf1b782a2e03680bb4a5ee43cc9d06bda172bac05b42'
 
-  url 'https://assets.ubuntu.com/v1/fad7939b-ubuntu-font-family-0.83.zip'
+  url "https://assets.ubuntu.com/v1/#{version.after_comma}-ubuntu-font-family-#{version.before_comma}.zip"
   name 'Ubuntu'
   homepage 'http://font.ubuntu.com/'
 
-  font "ubuntu-font-family-#{version}/Ubuntu-B.ttf"
-  font "ubuntu-font-family-#{version}/Ubuntu-BI.ttf"
-  font "ubuntu-font-family-#{version}/Ubuntu-C.ttf"
-  font "ubuntu-font-family-#{version}/Ubuntu-L.ttf"
-  font "ubuntu-font-family-#{version}/Ubuntu-LI.ttf"
-  font "ubuntu-font-family-#{version}/Ubuntu-M.ttf"
-  font "ubuntu-font-family-#{version}/Ubuntu-MI.ttf"
-  font "ubuntu-font-family-#{version}/Ubuntu-R.ttf"
-  font "ubuntu-font-family-#{version}/Ubuntu-RI.ttf"
-  font "ubuntu-font-family-#{version}/UbuntuMono-B.ttf"
-  font "ubuntu-font-family-#{version}/UbuntuMono-BI.ttf"
-  font "ubuntu-font-family-#{version}/UbuntuMono-R.ttf"
-  font "ubuntu-font-family-#{version}/UbuntuMono-RI.ttf"
+  font "ubuntu-font-family-#{version.before_comma}/Ubuntu-B.ttf"
+  font "ubuntu-font-family-#{version.before_comma}/Ubuntu-BI.ttf"
+  font "ubuntu-font-family-#{version.before_comma}/Ubuntu-C.ttf"
+  font "ubuntu-font-family-#{version.before_comma}/Ubuntu-L.ttf"
+  font "ubuntu-font-family-#{version.before_comma}/Ubuntu-LI.ttf"
+  font "ubuntu-font-family-#{version.before_comma}/Ubuntu-M.ttf"
+  font "ubuntu-font-family-#{version.before_comma}/Ubuntu-MI.ttf"
+  font "ubuntu-font-family-#{version.before_comma}/Ubuntu-R.ttf"
+  font "ubuntu-font-family-#{version.before_comma}/Ubuntu-RI.ttf"
+  font "ubuntu-font-family-#{version.before_comma}/UbuntuMono-B.ttf"
+  font "ubuntu-font-family-#{version.before_comma}/UbuntuMono-BI.ttf"
+  font "ubuntu-font-family-#{version.before_comma}/UbuntuMono-R.ttf"
+  font "ubuntu-font-family-#{version.before_comma}/UbuntuMono-RI.ttf"
 end

--- a/Casks/font-ubuntu.rb
+++ b/Casks/font-ubuntu.rb
@@ -2,7 +2,7 @@ cask 'font-ubuntu' do
   version '0.83'
   sha256 '456d7d42797febd0d7d4cf1b782a2e03680bb4a5ee43cc9d06bda172bac05b42'
 
-  url "http://font.ubuntu.com/download/ubuntu-font-family-#{version}.zip"
+  url 'https://assets.ubuntu.com/v1/fad7939b-ubuntu-font-family-0.83.zip'
   name 'Ubuntu'
   homepage 'http://font.ubuntu.com/'
 


### PR DESCRIPTION
Previous link was 302 to a webpage, breaking the install.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version.

**NB:**
- I didn't update the version so I didn't put the version in the commit message.
- I removed the version tag from the URL because the link seems to be hashed, so it needs changing anyway for future versions.