### PR TITLE
Update font-junicode to 1.001

### DIFF
--- a/Casks/font-junicode.rb
+++ b/Casks/font-junicode.rb
@@ -1,13 +1,16 @@
 cask 'font-junicode' do
-  version :latest
-  sha256 :no_check
+  version '1.001'
+  sha256 '64128229678d0fe1ae6f2897533932011af7dfcdeeba4d1148e45a8c6e439953'
 
-  url 'https://sourceforge.net/projects/junicode/files/latest/download'
+  url "https://downloads.sourceforge.net/junicode/junicode-#{version}.zip"
+  appcast 'https://sourceforge.net/projects/junicode/rss',
+          checkpoint: '4c3e44c809e0ec83ba47e38dcc9e0dce385d850ad2a65b628415447a9e0795d2'
   name 'Junicode'
   homepage 'http://junicode.sourceforge.net/'
 
-  font 'junicode/fonts/Junicode-Bold.ttf'
-  font 'junicode/fonts/Junicode-BoldItalic.ttf'
-  font 'junicode/fonts/Junicode-Italic.ttf'
-  font 'junicode/fonts/Junicode.ttf'
+  font 'FoulisGreek.ttf'
+  font 'Junicode-Bold.ttf'
+  font 'Junicode-BoldItalic.ttf'
+  font 'Junicode-Italic.ttf'
+  font 'Junicode.ttf'
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.