### PR TITLE
Add font-urw-base35 20170801

### DIFF
--- a/Casks/font-urw-base35.rb
+++ b/Casks/font-urw-base35.rb
@@ -1,0 +1,46 @@
+cask 'font-urw-base35' do
+  version '20170801'
+  sha256 '4505042c8859166f5bff77e33907e244b66eb4e04b56646e14e0a97e5757cd21'
+
+  url "https://github.com/ArtifexSoftware/urw-base35-fonts/archive/#{version}.zip"
+  appcast 'https://github.com/ArtifexSoftware/urw-base35-fonts/releases.atom',
+          checkpoint: '8959bea54204517533836c8693f68db7eea5009c6c1b898f477ed4e4b979049c'
+  name 'URW++ base 35'
+  homepage 'https://github.com/ArtifexSoftware/urw-base35-fonts'
+
+  font "urw-base35-fonts-#{version}/fonts/C059-BdIta.otf"
+  font "urw-base35-fonts-#{version}/fonts/C059-Bold.otf"
+  font "urw-base35-fonts-#{version}/fonts/C059-Italic.otf"
+  font "urw-base35-fonts-#{version}/fonts/C059-Roman.otf"
+  font "urw-base35-fonts-#{version}/fonts/D050000L.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusMonoPS-Bold.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusMonoPS-BoldItalic.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusMonoPS-Italic.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusMonoPS-Regular.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusRoman-Bold.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusRoman-BoldItalic.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusRoman-Italic.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusRoman-Regular.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusSans-Bold.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusSans-BoldItalic.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusSans-Italic.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusSans-Regular.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusSansNarrow-BdOblique.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusSansNarrow-Bold.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusSansNarrow-Oblique.otf"
+  font "urw-base35-fonts-#{version}/fonts/NimbusSansNarrow-Regular.otf"
+  font "urw-base35-fonts-#{version}/fonts/P052-Bold.otf"
+  font "urw-base35-fonts-#{version}/fonts/P052-BoldItalic.otf"
+  font "urw-base35-fonts-#{version}/fonts/P052-Italic.otf"
+  font "urw-base35-fonts-#{version}/fonts/P052-Roman.otf"
+  font "urw-base35-fonts-#{version}/fonts/StandardSymbolsPS.otf"
+  font "urw-base35-fonts-#{version}/fonts/URWBookman-Demi.otf"
+  font "urw-base35-fonts-#{version}/fonts/URWBookman-DemiItalic.otf"
+  font "urw-base35-fonts-#{version}/fonts/URWBookman-Light.otf"
+  font "urw-base35-fonts-#{version}/fonts/URWBookman-LightItalic.otf"
+  font "urw-base35-fonts-#{version}/fonts/URWGothic-Book.otf"
+  font "urw-base35-fonts-#{version}/fonts/URWGothic-BookOblique.otf"
+  font "urw-base35-fonts-#{version}/fonts/URWGothic-Demi.otf"
+  font "urw-base35-fonts-#{version}/fonts/URWGothic-DemiOblique.otf"
+  font "urw-base35-fonts-#{version}/fonts/Z003-MediumItalic.otf"
+end

--- a/Casks/font-urw-base35.rb
+++ b/Casks/font-urw-base35.rb
@@ -1,4 +1,5 @@
 cask 'font-urw-base35' do
+  # note: "35" is not a version number, but an intrinsic part of the product name
   version '20170801'
   sha256 '4505042c8859166f5bff77e33907e244b66eb4e04b56646e14e0a97e5757cd21'
 


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

Refs: https://github.com/caskroom/homebrew-fonts/pull/1401

The token matches the upstream repo and seems to be what the pack is known as.

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256