### PR TITLE
Update font-inconsolata-nerd-font to 1.2.0

### DIFF
--- a/Casks/font-inconsolata-nerd-font.rb
+++ b/Casks/font-inconsolata-nerd-font.rb
@@ -1,10 +1,10 @@
 cask 'font-inconsolata-nerd-font' do
-  version '1.1.0'
-  sha256 '869bdc6c23483a5de77f772ebd462daace203ff77cb03f3a6d476026e1c1a988'
+  version '1.2.0'
+  sha256 '6a94fdd4a81b1877c975acc6657a07ab844ec9de351416483dacaab2c01d7e2e'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Inconsolata.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
   name 'InconsolataForPowerline Nerd Font (Inconsolata)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.