### PR TITLE
Update font-3270-nerd-font-mono to 1.2.0

### DIFF
--- a/Casks/font-3270-nerd-font-mono.rb
+++ b/Casks/font-3270-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-3270-nerd-font-mono' do
-  version '1.1.0'
-  sha256 'a462873fb52827b99da63d5d8ea0ceb46276d3204782fd2417d8c469746da153'
+  version '1.2.0'
+  sha256 '37cd9e4c31b7f585a202ce85f358e318e6042de489e668c948ecee0d0daf4472'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/3270.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
   name '3270Medium Nerd Font (3270)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.