### PR TITLE
Update font-bitstreamverasansmono-nerd-font-mono to 1.2.0

### DIFF
--- a/Casks/font-bitstreamverasansmono-nerd-font-mono.rb
+++ b/Casks/font-bitstreamverasansmono-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-bitstreamverasansmono-nerd-font-mono' do
-  version '1.1.0'
-  sha256 'e984c2c1e9971555c061b95c8c247c391cb3c0795346d8a56e2f36790e62ac44'
+  version '1.2.0'
+  sha256 'caa575cf0df9ab974f531c681b9ec9c7fb9a1b313e336bb820d5a6627857e95d'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/BitstreamVeraSansMono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
   name 'BitstreamVeraSansMono Nerd Font (BitstreamVeraSansMono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.