### PR TITLE
Update font-firacode-nerd-font-mono to 1.2.0

### DIFF
--- a/Casks/font-firacode-nerd-font-mono.rb
+++ b/Casks/font-firacode-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-firacode-nerd-font-mono' do
-  version '1.1.0'
-  sha256 '551309fad856238876d051bfb2d81d9c85707f797de562529cb5aa2505e2ac7d'
+  version '1.2.0'
+  sha256 '54f1ade117e2efcc7386d3578da27b13c58b0e7e6afc2212b858ce0716d9d915'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/FiraCode.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
   name 'FuraCode Nerd Font (FiraCode)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.