### PR TITLE
Update font-firamono-nerd-font-mono to 1.2.0

### DIFF
--- a/Casks/font-firamono-nerd-font-mono.rb
+++ b/Casks/font-firamono-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-firamono-nerd-font-mono' do
-  version '1.1.0'
-  sha256 'c2b5f1928e79ff5738b1aacf8642c68abd3bc5d4ae2db86aa9ac52e7cd2cd25e'
+  version '1.2.0'
+  sha256 '77ffee4498e23e3215edc9ea6eefa9f10b03deb6815dc3ccb9ad3336cd478f5c'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/FiraMono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
   name 'FuraMonoForPowerline Nerd Font (FiraMono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.