### PR TITLE
Update font-hack-nerd-font-mono to 1.2.0

### DIFF
--- a/Casks/font-hack-nerd-font-mono.rb
+++ b/Casks/font-hack-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-hack-nerd-font-mono' do
-  version '1.1.0'
-  sha256 'ceebc8767d79b774b631c56fec1082b008310b0c6e5bb4b8e8826027ec6db882'
+  version '1.2.0'
+  sha256 'f1c2b5864903a2f2803da73be13541dd4e48d0fcf4cac5631112bfdf7577ee43'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Hack.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
   name 'Knack Nerd Font (Hack)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.