### PR TITLE
Update font-heavydata-nerd-font-mono to 1.2.0

### DIFF
--- a/Casks/font-heavydata-nerd-font-mono.rb
+++ b/Casks/font-heavydata-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-heavydata-nerd-font-mono' do
-  version '1.1.0'
-  sha256 '3a1eda8eaa51c7a6e96b73e6c0e73022d1257c2d213398cf7a595686c7445bbd'
+  version '1.2.0'
+  sha256 '101310c911cc41e159e100a9afc2df3bc5d2e212475c9a53eec785904d9135cf'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/HeavyData.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
   name 'HeavyData Nerd Font (HeavyData)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.