### PR TITLE
Update font-hermit-nerd-font-mono to 1.2.0

### DIFF
--- a/Casks/font-hermit-nerd-font-mono.rb
+++ b/Casks/font-hermit-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-hermit-nerd-font-mono' do
-  version '1.1.0'
-  sha256 'aef8e5496298b986b5a6be8ef0408652f6ed2fa0868a8c44f4be79f6d0c16e36'
+  version '1.2.0'
+  sha256 '98da4c26a22cf7d8c3161e71d7ae5ebfa592b8312dc39426db646a1f32623b25'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Hermit.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
   name 'Hurmit Nerd Font (Hermit)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.