### PR TITLE
Update font-liberationmono-nerd-font-mono to 1.2.0

### DIFF
--- a/Casks/font-liberationmono-nerd-font-mono.rb
+++ b/Casks/font-liberationmono-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-liberationmono-nerd-font-mono' do
-  version '1.1.0'
-  sha256 '3894056c0825a3dde3ee9a7ee65bff5a44b936b60eaebf4a374b0d26ba55dc9e'
+  version '1.2.0'
+  sha256 '8eb8f93c4a4ea15044790ddc1dfd50c5acaf883a2f2e6cb148a5e0a2e0224547'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/LiberationMono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
   name 'LiterationMonoPowerline Nerd Font (LiberationMono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.