### PR TITLE
Update font-mononoki-nerd-font-mono to 1.2.0

### DIFF
--- a/Casks/font-mononoki-nerd-font-mono.rb
+++ b/Casks/font-mononoki-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-mononoki-nerd-font-mono' do
-  version '1.1.0'
-  sha256 '721ca12da8869216670b77bc106e35095c5fe2ab9422a9e1151626584c52b9c7'
+  version '1.2.0'
+  sha256 'c06fd6193ab463cb76ec1712a2a7d1b505bebac7918db22f3c111435c19525b5'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Mononoki.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
   name 'mononoki Nerd Font (Mononoki)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.