### PR TITLE
Update font-mplus-nerd-font-mono to 1.2.0

### DIFF
--- a/Casks/font-mplus-nerd-font-mono.rb
+++ b/Casks/font-mplus-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-mplus-nerd-font-mono' do
-  version '1.1.0'
-  sha256 '3d5f7cb08eaeb22c256d5c62af807e4ddc66f5d9834590b9abdb0728e08f0125'
+  version '1.2.0'
+  sha256 'acd1401bfd0de8804db02c782e01e03ccf9fc9fe78d056d73f7f352b07269230'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/MPlus.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
   name 'mplus Nerd Font (MPlus)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.