### PR TITLE
Update font-profont-nerd-font-mono to 1.2.0

### DIFF
--- a/Casks/font-profont-nerd-font-mono.rb
+++ b/Casks/font-profont-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-profont-nerd-font-mono' do
-  version '1.1.0'
-  sha256 '4463c9f5a4dd1dbd27d198c893819e7552d77e607f33e806e0b916fc506f7694'
+  version '1.2.0'
+  sha256 '18c12f8b6d58c65a66a7ed5b94a57bf527b940e8924d5e6f9a48cf447a3067ff'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/ProFont.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '109f18cfd453156e38ffac165683bcfc2745e0c8dc07bd379a7f9ea19d0cbe41'
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
   name 'ProFontIIx Nerd Font (ProFont)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.