### PR TITLE
Update font Cica version to 2.0.5

### DIFF
--- a/Casks/font-cica.rb
+++ b/Casks/font-cica.rb
@@ -1,10 +1,10 @@
 cask 'font-cica' do
-  version '2.0.4'
-  sha256 'e1b99f97983934c18cac772273df660dd5c247c08e03612ec320ef7de4d66f65'
+  version '2.0.5'
+  sha256 '226d4ef7cdaad2f34c072e899a17ff85f5d01b068735d2d3ea3f8b34a9499ddd'
 
   url "https://github.com/miiton/Cica/releases/download/v#{version}/Cica_v#{version}.zip"
   appcast 'https://github.com/miiton/Cica/releases.atom',
-          checkpoint: '4a0c59af37e1a5a52f8bf8350c137797b45157a963d5e685bbadd6555e6ee4b2'
+          checkpoint: '271dd303e57f9417d4ff235d6d6f69f566134bc9cbcba0dc3a94d2d61f9efee1'
   name 'Cica'
   homepage 'https://github.com/miiton/Cica'
 


### PR DESCRIPTION
https://github.com/miiton/Cica/releases/tag/v2.0.5

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
