### PR TITLE
Adds 14 new Nerd Fonts from 1.2.0 release

### DIFF
--- a/Casks/font-arimo-nerd-font-mono.rb
+++ b/Casks/font-arimo-nerd-font-mono.rb
@@ -1,0 +1,15 @@
+cask 'font-arimo-nerd-font-mono' do
+  version '1.2.0'
+  sha256 'c68c0c85c1c7211f425675b94941468a5a7a670ed91bab2a2b4ecbdd1655c940'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Arimo.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'Arimo Nerd Font Mono (Arimo)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'Arimo Bold Nerd Font Complete Mono.ttf'
+  font 'Arimo Bold Italic Nerd Font Complete Mono.ttf'
+  font 'Arimo Regular Nerd Font Complete Mono.ttf'
+  font 'Arimo Italic Nerd Font Complete Mono.ttf'
+end

--- a/Casks/font-arimo-nerd-font.rb
+++ b/Casks/font-arimo-nerd-font.rb
@@ -1,0 +1,15 @@
+cask 'font-arimo-nerd-font' do
+  version '1.2.0'
+  sha256 'c68c0c85c1c7211f425675b94941468a5a7a670ed91bab2a2b4ecbdd1655c940'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Arimo.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'Arimo Nerd Font (Arimo)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'Arimo Bold Nerd Font Complete.ttf'
+  font 'Arimo Bold Italic Nerd Font Complete.ttf'
+  font 'Arimo Regular Nerd Font Complete.ttf'
+  font 'Arimo Italic Nerd Font Complete.ttf'
+end

--- a/Casks/font-cousine-nerd-font-mono.rb
+++ b/Casks/font-cousine-nerd-font-mono.rb
@@ -1,0 +1,15 @@
+cask 'font-cousine-nerd-font-mono' do
+  version '1.2.0'
+  sha256 'ee8576c433de415fc52ee59985e46eb510c3dd8e6ab516c409804d0e05ae77e7'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Cousine.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'Cousine Nerd Font Mono (Cousine)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'Cousine Bold Nerd Font Complete Mono.ttf'
+  font 'Cousine Bold Italic Nerd Font Complete Mono.ttf'
+  font 'Cousine Regular Nerd Font Complete Mono.ttf'
+  font 'Cousine Italic Nerd Font Complete Mono.ttf'
+end

--- a/Casks/font-cousine-nerd-font.rb
+++ b/Casks/font-cousine-nerd-font.rb
@@ -1,0 +1,15 @@
+cask 'font-cousine-nerd-font' do
+  version '1.2.0'
+  sha256 'ee8576c433de415fc52ee59985e46eb510c3dd8e6ab516c409804d0e05ae77e7'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Cousine.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'Cousine Nerd Font (Cousine)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'Cousine Bold Nerd Font Complete.ttf'
+  font 'Cousine Bold Italic Nerd Font Complete.ttf'
+  font 'Cousine Regular Nerd Font Complete.ttf'
+  font 'Cousine Italic Nerd Font Complete.ttf'
+end

--- a/Casks/font-go-mono-nerd-font-mono.rb
+++ b/Casks/font-go-mono-nerd-font-mono.rb
@@ -1,0 +1,15 @@
+cask 'font-go-mono-nerd-font-mono' do
+  version '1.2.0'
+  sha256 'c6873e9563766a6ff9b36b35d25366bad406a0423b181a33cda6a8e58dd4bfc9'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Go-Mono.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'GoMono Nerd Font Mono (Go-Mono)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'Go Mono Italic Nerd Font Complete Mono.ttf'
+  font 'Go Mono Nerd Font Complete Mono.ttf'
+  font 'Go Mono Bold Italic Nerd Font Complete Mono.ttf'
+  font 'Go Mono Bold Nerd Font Complete Mono.ttf'
+end

--- a/Casks/font-go-mono-nerd-font.rb
+++ b/Casks/font-go-mono-nerd-font.rb
@@ -1,0 +1,15 @@
+cask 'font-go-mono-nerd-font' do
+  version '1.2.0'
+  sha256 'c6873e9563766a6ff9b36b35d25366bad406a0423b181a33cda6a8e58dd4bfc9'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Go-Mono.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'GoMono Nerd Font (Go-Mono)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'Go Mono Nerd Font Complete.ttf'
+  font 'Go Mono Bold Italic Nerd Font Complete.ttf'
+  font 'Go Mono Italic Nerd Font Complete.ttf'
+  font 'Go Mono Bold Nerd Font Complete.ttf'
+end

--- a/Casks/font-inconsolatago-nerd-font-mono.rb
+++ b/Casks/font-inconsolatago-nerd-font-mono.rb
@@ -1,0 +1,13 @@
+cask 'font-inconsolatago-nerd-font-mono' do
+  version '1.2.0'
+  sha256 'ef29ebe90bbb54b2d2e81a2f22acc423f8ece2d0910a24c428fd3220635ba9fc'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/InconsolataGo.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'InconsolataGo Nerd Font Mono (InconsolataGo)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'InconsolataGo Bold Nerd Font Complete Mono.ttf'
+  font 'InconsolataGo Nerd Font Complete Mono.ttf'
+end

--- a/Casks/font-inconsolatago-nerd-font.rb
+++ b/Casks/font-inconsolatago-nerd-font.rb
@@ -1,0 +1,13 @@
+cask 'font-inconsolatago-nerd-font' do
+  version '1.2.0'
+  sha256 'ef29ebe90bbb54b2d2e81a2f22acc423f8ece2d0910a24c428fd3220635ba9fc'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/InconsolataGo.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'InconsolataGo Nerd Font (InconsolataGo)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'InconsolataGo Bold Nerd Font Complete.ttf'
+  font 'InconsolataGo Nerd Font Complete.ttf'
+end

--- a/Casks/font-inconsolatalgc-nerd-font-mono.rb
+++ b/Casks/font-inconsolatalgc-nerd-font-mono.rb
@@ -1,0 +1,15 @@
+cask 'font-inconsolatalgc-nerd-font-mono' do
+  version '1.2.0'
+  sha256 '0fd2492b0c5c4140718120ae97517efb0236694b1a3e10252492addfc38fffda'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/InconsolataLGC.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'InconsolataLGC Nerd Font Mono (InconsolataLGC)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'Inconsolata LGC Bold Nerd Font Complete Mono.ttf'
+  font 'Inconsolata LGC Bold Italic Nerd Font Complete Mono.ttf'
+  font 'Inconsolata LGC Italic Nerd Font Complete Mono.ttf'
+  font 'Inconsolata LGC Nerd Font Complete Mono.ttf'
+end

--- a/Casks/font-inconsolatalgc-nerd-font.rb
+++ b/Casks/font-inconsolatalgc-nerd-font.rb
@@ -1,0 +1,15 @@
+cask 'font-inconsolatalgc-nerd-font' do
+  version '1.2.0'
+  sha256 '0fd2492b0c5c4140718120ae97517efb0236694b1a3e10252492addfc38fffda'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/InconsolataLGC.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'InconsolataLGC Nerd Font (InconsolataLGC)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'Inconsolata LGC Bold Nerd Font Complete.ttf'
+  font 'Inconsolata LGC Nerd Font Complete.ttf'
+  font 'Inconsolata LGC Bold Italic Nerd Font Complete.ttf'
+  font 'Inconsolata LGC Italic Nerd Font Complete.ttf'
+end

--- a/Casks/font-tinos-nerd-font-mono.rb
+++ b/Casks/font-tinos-nerd-font-mono.rb
@@ -1,0 +1,15 @@
+cask 'font-tinos-nerd-font-mono' do
+  version '1.2.0'
+  sha256 'b8e90e6a3cdaff3fff2f928295d4000f07eb75fd5fa6fa72a88304891ee0cc1c'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Tinos.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'Tinos Nerd Font Mono (Tinos)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'Tinos Nerd Font Complete Mono.ttf'
+  font 'Tinos Italic Nerd Font Complete Mono.ttf'
+  font 'Tinos Bold Italic Nerd Font Complete Mono.ttf'
+  font 'Tinos Bold Nerd Font Complete Mono.ttf'
+end

--- a/Casks/font-tinos-nerd-font.rb
+++ b/Casks/font-tinos-nerd-font.rb
@@ -1,0 +1,15 @@
+cask 'font-tinos-nerd-font' do
+  version '1.2.0'
+  sha256 'b8e90e6a3cdaff3fff2f928295d4000f07eb75fd5fa6fa72a88304891ee0cc1c'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Tinos.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'Tinos Nerd Font (Tinos)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'Tinos Nerd Font Complete.ttf'
+  font 'Tinos Italic Nerd Font Complete.ttf'
+  font 'Tinos Bold Nerd Font Complete.ttf'
+  font 'Tinos Bold Italic Nerd Font Complete.ttf'
+end

--- a/Casks/font-ubuntu-nerd-font-mono.rb
+++ b/Casks/font-ubuntu-nerd-font-mono.rb
@@ -1,0 +1,20 @@
+cask 'font-ubuntu-nerd-font-mono' do
+  version '1.2.0'
+  sha256 '7d386304371ef6b3f265a317307d5562cf4c536b45d8bfbf795b64678a2b00bf'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Ubuntu.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'Ubuntu Nerd Font Mono (Ubuntu)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'Ubuntu Bold Nerd Font Complete Mono.ttf'
+  font 'Ubuntu Italic Nerd Font Complete Mono.ttf'
+  font 'Ubuntu Bold Italic Nerd Font Complete Mono.ttf'
+  font 'Ubuntu Medium Nerd Font Complete Mono.ttf'
+  font 'Ubuntu Nerd Font Complete Mono.ttf'
+  font 'Ubuntu Medium Italic Nerd Font Complete Mono.ttf'
+  font 'Ubuntu Condensed Nerd Font Complete Mono.ttf'
+  font 'Ubuntu Light Nerd Font Complete Mono.ttf'
+  font 'Ubuntu Light Italic Nerd Font Complete Mono.ttf'
+end

--- a/Casks/font-ubuntu-nerd-font.rb
+++ b/Casks/font-ubuntu-nerd-font.rb
@@ -1,0 +1,20 @@
+cask 'font-ubuntu-nerd-font' do
+  version '1.2.0'
+  sha256 '7d386304371ef6b3f265a317307d5562cf4c536b45d8bfbf795b64678a2b00bf'
+
+  url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Ubuntu.zip"
+  appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
+          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+  name 'Ubuntu Nerd Font (Ubuntu)'
+  homepage 'https://github.com/ryanoasis/nerd-fonts'
+
+  font 'Ubuntu Bold Nerd Font Complete.ttf'
+  font 'Ubuntu Italic Nerd Font Complete.ttf'
+  font 'Ubuntu Bold Italic Nerd Font Complete.ttf'
+  font 'Ubuntu Medium Nerd Font Complete.ttf'
+  font 'Ubuntu Nerd Font Complete.ttf'
+  font 'Ubuntu Medium Italic Nerd Font Complete.ttf'
+  font 'Ubuntu Condensed Nerd Font Complete.ttf'
+  font 'Ubuntu Light Nerd Font Complete.ttf'
+  font 'Ubuntu Light Italic Nerd Font Complete.ttf'
+end


### PR DESCRIPTION
* Adds font-arimo-nerd-font-mono
* Adds font-arimo-nerd-font
* Adds font-cousine-nerd-font-mono
* Adds font-cousine-nerd-font
* Adds font-go-mono-nerd-font-mono
* Adds font-go-mono-nerd-font
* Adds font-inconsolatago-nerd-font-mono
* Adds font-inconsolatago-nerd-font
* Adds font-inconsolatalgc-nerd-font-mono
* Adds font-inconsolatalgc-nerd-font
* Adds font-tinos-nerd-font-mono
* Adds font-tinos-nerd-font
* Adds font-ubuntu-nerd-font-mono
* Adds font-ubuntu-nerd-font

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free. **(did/could not see below)***
- [ ] `brew cask style --fix {{cask_file}}` reports no offenses. **(did/could not see below)***
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully. **(did/could not see below)***
- [ ] `brew cask uninstall {{cask_file}}` worked successfully. **(did/could not see below)***
- [ ] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256

**Could not test as I have no access to macOS however this uses the same [script](https://github.com/ryanoasis/nerd-fonts/blob/1.2.0/bin/scripts/generate-casks.sh) used to generate the initial seeded casks for the other Nerd Font casks that are in the repo already***

related to closed issue: #1437
