### PR TITLE
Update font-luculent, font-m-plus: remove xz dependancy

### DIFF
--- a/Casks/font-luculent.rb
+++ b/Casks/font-luculent.rb
@@ -6,8 +6,6 @@ cask 'font-luculent' do
   name 'Luculent'
   homepage 'http://eastfarthing.com/luculent/'
 
-  depends_on formula: 'xz'
-
   font 'luculent/luculent.ttf'
   font 'luculent/luculentb.ttf'
   font 'luculent/luculentbi.ttf'

--- a/Casks/font-m-plus.rb
+++ b/Casks/font-m-plus.rb
@@ -6,8 +6,6 @@ cask 'font-m-plus' do
   name 'M+ FONTS'
   homepage 'https://mplus-fonts.osdn.jp/about-en.html'
 
-  depends_on formula: 'xz'
-
   font "mplus-TESTFLIGHT-#{version}/mplus-1c-black.ttf"
   font "mplus-TESTFLIGHT-#{version}/mplus-1c-bold.ttf"
   font "mplus-TESTFLIGHT-#{version}/mplus-1c-heavy.ttf"


### PR DESCRIPTION
Refs: https://github.com/caskroom/homebrew-fonts/issues/176

`xz` is not required for `>=10.10`