### PR TITLE
Update 15 existing Noto font families (part 5)

### DIFF
--- a/Casks/font-noto-sans-new-tai-lue.rb
+++ b/Casks/font-noto-sans-new-tai-lue.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-new-tai-lue' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansNewTaiLue-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansNewTaiLue-unhinted.zip'
   name 'Noto Sans New Tai Lue'
   homepage 'https://www.google.com/get/noto/#sans-talu'
 

--- a/Casks/font-noto-sans-ogham.rb
+++ b/Casks/font-noto-sans-ogham.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-ogham' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOgham-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansOgham-unhinted.zip'
   name 'Noto Sans Ogham'
   homepage 'https://www.google.com/get/noto/#sans-ogam'
 

--- a/Casks/font-noto-sans-ol-chiki.rb
+++ b/Casks/font-noto-sans-ol-chiki.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-ol-chiki' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOlChiki-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansOlChiki-unhinted.zip'
   name 'Noto Sans Ol Chiki'
   homepage 'https://www.google.com/get/noto/#sans-olck'
 

--- a/Casks/font-noto-sans-old-italic.rb
+++ b/Casks/font-noto-sans-old-italic.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-old-italic' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOldItalic-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansOldItalic-unhinted.zip'
   name 'Noto Sans Old Italic'
   homepage 'https://www.google.com/get/noto/#sans-ital'
 

--- a/Casks/font-noto-sans-old-persian.rb
+++ b/Casks/font-noto-sans-old-persian.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-old-persian' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOldPersian-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansOldPersian-unhinted.zip'
   name 'Noto Sans Old Persian'
   homepage 'https://www.google.com/get/noto/#sans-xpeo'
 

--- a/Casks/font-noto-sans-old-south-arabian.rb
+++ b/Casks/font-noto-sans-old-south-arabian.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-old-south-arabian' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOldSouthArabian-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansOldSouthArabian-unhinted.zip'
   name 'Noto Sans Old South Arabian'
   homepage 'https://www.google.com/get/noto/#sans-sarb'
 

--- a/Casks/font-noto-sans-old-turkic.rb
+++ b/Casks/font-noto-sans-old-turkic.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-old-turkic' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOldTurkic-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansOldTurkic-unhinted.zip'
   name 'Noto Sans Old Turkic'
   homepage 'https://www.google.com/get/noto/#sans-orkh'
 

--- a/Casks/font-noto-sans-oriya.rb
+++ b/Casks/font-noto-sans-oriya.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-oriya' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOriya-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansOriya-unhinted.zip'
   name 'Noto Sans Oriya'
   homepage 'https://www.google.com/get/noto/#sans-orya'
 

--- a/Casks/font-noto-sans-osmanya.rb
+++ b/Casks/font-noto-sans-osmanya.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-osmanya' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansOsmanya-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansOsmanya-unhinted.zip'
   name 'Noto Sans Osmanya'
   homepage 'https://www.google.com/get/noto/#sans-osma'
 

--- a/Casks/font-noto-sans-phags-pa.rb
+++ b/Casks/font-noto-sans-phags-pa.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-phags-pa' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansPhagsPa-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansPhagsPa-unhinted.zip'
   name 'Noto Sans Phags Pa'
   homepage 'https://www.google.com/get/noto/#sans-phag'
 

--- a/Casks/font-noto-sans-phoenician.rb
+++ b/Casks/font-noto-sans-phoenician.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-phoenician' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansPhoenician-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansPhoenician-unhinted.zip'
   name 'Noto Sans Phoenician'
   homepage 'https://www.google.com/get/noto/#sans-phnx'
 

--- a/Casks/font-noto-sans-rejang.rb
+++ b/Casks/font-noto-sans-rejang.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-rejang' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansRejang-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansRejang-unhinted.zip'
   name 'Noto Sans Rejang'
   homepage 'https://www.google.com/get/noto/#sans-rjng'
 

--- a/Casks/font-noto-sans-runic.rb
+++ b/Casks/font-noto-sans-runic.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-runic' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansRunic-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansRunic-unhinted.zip'
   name 'Noto Sans Runic'
   homepage 'https://www.google.com/get/noto/#sans-runr'
 

--- a/Casks/font-noto-sans-samaritan.rb
+++ b/Casks/font-noto-sans-samaritan.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-samaritan' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansSamaritan-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansSamaritan-unhinted.zip'
   name 'Noto Sans Samaritan'
   homepage 'https://www.google.com/get/noto/#sans-samr'
 

--- a/Casks/font-noto-sans-saurashtra.rb
+++ b/Casks/font-noto-sans-saurashtra.rb
@@ -2,8 +2,8 @@ cask 'font-noto-sans-saurashtra' do
   version :latest
   sha256 :no_check
 
-  # noto-website.storage.googleapis.com was verified as official when first introduced to the cask
-  url 'https://noto-website.storage.googleapis.com/pkgs/NotoSansSaurashtra-unhinted.zip'
+  # noto-website-2.storage.googleapis.com was verified as official when first introduced to the cask
+  url 'https://noto-website-2.storage.googleapis.com/pkgs/NotoSansSaurashtra-unhinted.zip'
   name 'Noto Sans Saurashtra'
   homepage 'https://www.google.com/get/noto/#sans-saur'
 


### PR DESCRIPTION
This PR is part of a series of PRs add new font families and updating existing ones as part of the Noto Fonts project’s [Phase 3](https://www.google.com/get/noto/updates/). 

This PR updates the following Noto font families:
- Noto Sans New Tai Lue
- Noto Sans Ogham
- Noto Sans Ol Chiki
- Noto Sans Old Italic
- Noto Sans Old Persian
- Noto Sans Old South Arabian
- Noto Sans Old Turkic
- Noto Sans Oriya
- Noto Sans Osmanya
- Noto Sans Phags Pa
- Noto Sans Phoenician
- Noto Sans Rejang
- Noto Sans Runic
- Noto Sans Samaritan
- Noto Sans Saurashtra

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
