### PR TITLE
Update font-amiri to 0.111

### DIFF
--- a/Casks/font-amiri.rb
+++ b/Casks/font-amiri.rb
@@ -1,11 +1,11 @@
 cask 'font-amiri' do
-  version '0.109'
-  sha256 '97ee6e40d87f4b31de15d9a93bb30bf27bf308f0814f4ee9c47365b027402ad6'
+  version '0.111'
+  sha256 '1fbfccced6348b5db2c1c21d5b319cd488e14d055702fa817a0f6cb83d882166'
 
   # github.com/alif-type/amiri-font was verified as official when first introduced to the cask
   url "https://github.com/alif-type/amiri-font/releases/download/#{version}/amiri-#{version}.zip"
   appcast 'https://github.com/alif-type/amiri/releases.atom',
-          checkpoint: '14d9f7389297cb9dc87490696dd57500cc7605da7f2936dde989fbe2ed7c3afb'
+          checkpoint: '8a2b9100d45a0b6501b16fa61ec40284cf4d6f671671da4ded3030948a2f6b89'
   name 'Amiri'
   homepage 'http://www.amirifont.org/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.