### PR TITLE
Update font-d2coding to 1.3.1,20180115

### DIFF
--- a/Casks/font-d2coding.rb
+++ b/Casks/font-d2coding.rb
@@ -8,5 +8,5 @@ cask 'font-d2coding' do
   name 'D2 Coding'
   homepage 'https://github.com/naver/d2codingfont'
 
-  font "D2Coding-Ver#{version.before_comma}-#{version.after_comma}/D2Coding-Ver#{version.before_comma}-#{version.after_comma}.ttc"
+  font "D2Coding-Ver#{version.before_comma}-#{version.after_comma}/D2Coding/D2Coding-Ver#{version.before_comma}-#{version.after_comma}.ttc"
 end

--- a/Casks/font-d2coding.rb
+++ b/Casks/font-d2coding.rb
@@ -1,12 +1,12 @@
 cask 'font-d2coding' do
-  version '1.3,Ver1.3-20171129'
-  sha256 '3be175e6969852c6e7501c0a1afa387a6ac845e583c5c2510fa069551e567cdd'
+  version '1.3.1,20180115'
+  sha256 '06f3fdb7a5a02e695af47ae95bd246713745e191628fd9a1bea670a67528b82c'
 
-  url "https://github.com/naver/d2codingfont/releases/download/VER#{version.before_comma}/D2Coding-#{version.after_comma}.zip"
+  url "https://github.com/naver/d2codingfont/releases/download/VER#{version.before_comma}/D2Coding-Ver#{version.before_comma}-#{version.after_comma}.zip"
   appcast 'https://github.com/naver/d2codingfont/releases.atom',
-          checkpoint: '63d857249403dd983c2a79e390f9f4c0b7706eded063d834d5daad7c5d801c50'
+          checkpoint: '7624423ea790852c136928f39779d169315f5df1fb880eec077f7d4c7251ac3a'
   name 'D2 Coding'
   homepage 'https://github.com/naver/d2codingfont'
 
-  font "D2Coding-#{version.after_comma}/D2Coding-#{version.after_comma}.ttc"
+  font "D2Coding-Ver#{version.before_comma}-#{version.after_comma}/D2Coding-Ver#{version.before_comma}-#{version.after_comma}.ttc"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.