### PR TITLE
Update font-fantasque-sans-mono to 1.7.2

### DIFF
--- a/Casks/font-fantasque-sans-mono.rb
+++ b/Casks/font-fantasque-sans-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-fantasque-sans-mono' do
-  version '1.7.1'
-  sha256 '6bb3b24413b78eed19ffa9bd233ae555982e3b185bd303e57dd1e05bebf17352'
+  version '1.7.2'
+  sha256 'f3c712d02b3f1f78a2ba1e5be95f1366e75f910b22b7b9242449b2bd43d1f194'
 
-  url "https://github.com/belluzj/fantasque-sans/releases/download/v#{version}/FantasqueSansMono.zip"
+  url "https://github.com/belluzj/fantasque-sans/releases/download/v#{version}/FantasqueSansMono-Normal.zip"
   appcast 'https://github.com/belluzj/fantasque-sans/releases.atom',
-          checkpoint: 'ad0c508b0cf280b5e16618b64299a19c628eabf7c6f470262ba9b8c244463864'
+          checkpoint: '6b2ca51858c9dab27a54407c13af2e760c477e0bd66190c42f4334e40960ba6b'
   name 'Fantasque Sans Mono'
   homepage 'https://github.com/belluzj/fantasque-sans'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.