### PR TITLE
Fix typo in caveat of font-source-han-serif-sb-h 1.001R

### DIFF
--- a/Casks/font-source-han-serif-sb-h.rb
+++ b/Casks/font-source-han-serif-sb-h.rb
@@ -16,6 +16,6 @@ cask 'font-source-han-serif-sb-h' do
     #{token} only installs the SemiBold, Bold, and Heavy weights.
     To install ExtraLight, Light, Regular, and Medium:
 
-      brew cask install font-source-han-serif-sb-h
+      brew cask install font-source-han-serif-el-m
   EOS
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [ ] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Errors occurred during audit, even when using the current (master) version of the cask:

```
 - appcast checkpoint mismatch
Expected: 47de4f7140b72957ecb8063853cecc20533fea5f9fd280a1b70da851348690e5
Actual: 30bc2a7f23172a662eaafd04e751f5b106f29b1430033a4512682527e19968cc
```

Additionally, if **adding a new cask**:

- [ ] Named the cask according to the [token reference].
- [ ] `brew cask install {{cask_file}}` worked successfully.
- [ ] `brew cask uninstall {{cask_file}}` worked successfully.
- [ ] Checked there are no [open pull requests] for the same cask.
- [ ] Checked the cask was not already refused in [closed issues].
- [ ] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
