### PR TITLE
Update font-parastoo to 1.0.0-alpha5

### DIFF
--- a/Casks/font-parastoo.rb
+++ b/Casks/font-parastoo.rb
@@ -1,11 +1,11 @@
 cask 'font-parastoo' do
-  version '1.0.0-alpha3'
-  sha256 '7e02a35c0755317f2680a2d5f57cacc2503309a75b28062244ec26fc1a0a162f'
+  version '1.0.0-alpha5'
+  sha256 'e7459d2b556e30a3bab72f719329d2b92b30ccc9152b59b25645ddb314b1538e'
 
   # github.com/rastikerdar was verified as official when first introduced to the cask
   url "https://github.com/rastikerdar/parastoo-font/releases/download/v#{version}/parastoo-font-v#{version}.zip"
   appcast 'https://github.com/rastikerdar/parastoo-font/releases.atom',
-          checkpoint: '0cdbdf8250e744f6cca84ab68b04f28e7031924f363f80b09babea4de84e6af7'
+          checkpoint: 'f690a8d64d70d132e60219b97bf718c1ed15326b886dc12cc5379ffd7edcd739'
   name 'Parastoo'
   homepage 'http://rastikerdar.github.io/parastoo-font'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.