### PR TITLE
Update font-xits to 1.108

### DIFF
--- a/Casks/font-xits.rb
+++ b/Casks/font-xits.rb
@@ -1,17 +1,17 @@
 cask 'font-xits' do
   version '1.108'
-  sha256 'af5e3eee5c81578810a7f2ffbf4c985d25e879e0128ea1dd6c1389a06eb36347'
+  sha256 '246c5a8a5e10b5a55a13623a04f62c7e3f4a0453e5df8c338c11ebc0ad94d8d6'
 
-  url "https://github.com/khaledhosny/xits-math/archive/v#{version}.zip"
-  appcast 'https://github.com/khaledhosny/xits-math/releases.atom',
-          checkpoint: 'b95fbba398884408c293eba5cb6e1e556f0c337db397dd39f20d700634c0e287'
+  url "https://github.com/khaledhosny/xits/archive/v#{version}.zip"
+  appcast 'https://github.com/khaledhosny/xits/releases.atom',
+          checkpoint: '29a935bed910b7f6a65d5808a0f3d86e562195894b520307f207d65558ce47d3'
   name 'XITS'
-  homepage 'https://github.com/khaledhosny/xits-math'
+  homepage 'https://github.com/khaledhosny/xits'
 
-  font "xits-math-#{version}/xits-bold.otf"
-  font "xits-math-#{version}/xits-bolditalic.otf"
-  font "xits-math-#{version}/xits-italic.otf"
-  font "xits-math-#{version}/xits-math.otf"
-  font "xits-math-#{version}/xits-mathbold.otf"
-  font "xits-math-#{version}/xits-regular.otf"
+  font "xits-#{version}/xits-bold.otf"
+  font "xits-#{version}/xits-bolditalic.otf"
+  font "xits-#{version}/xits-italic.otf"
+  font "xits-#{version}/xits-math.otf"
+  font "xits-#{version}/xits-mathbold.otf"
+  font "xits-#{version}/xits-regular.otf"
 end


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.