### PR TITLE
Update font-hack to 3.001

### DIFF
--- a/Casks/font-hack.rb
+++ b/Casks/font-hack.rb
@@ -1,11 +1,11 @@
 cask 'font-hack' do
-  version '3.000'
-  sha256 '238765b81e88dd207d241a6ae46abeab37346d850566334fc1cca8221ea6da40'
+  version '3.001'
+  sha256 'd44c6da35adda58f330d96212a59e16fdc35311fe2f495f6b0e3b156d633788e'
 
   # github.com/source-foundry/Hack was verified as official when first introduced to the cask
   url "https://github.com/source-foundry/Hack/releases/download/v#{version}/Hack-v#{version}-ttf.zip"
   appcast 'https://github.com/source-foundry/Hack/releases.atom',
-          checkpoint: 'faf7232c5570d40cd2b95d73ddafe6d405f3badb19f72a914821ec748d63fd22'
+          checkpoint: '9283b6f55b192df976de026543ee62cd4576d8e60a186e02cc89a8b55f4cc90f'
   name 'Hack'
   homepage 'http://sourcefoundry.org/hack/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.