### PR TITLE
Update font-hack to 3.002

### DIFF
--- a/Casks/font-hack.rb
+++ b/Casks/font-hack.rb
@@ -1,11 +1,11 @@
 cask 'font-hack' do
-  version '3.001'
-  sha256 'd44c6da35adda58f330d96212a59e16fdc35311fe2f495f6b0e3b156d633788e'
+  version '3.002'
+  sha256 '1dc0acdbf790bd6143248cbe672bccea066031c07d5e9cede3ae67213f53d7a1'
 
   # github.com/source-foundry/Hack was verified as official when first introduced to the cask
   url "https://github.com/source-foundry/Hack/releases/download/v#{version}/Hack-v#{version}-ttf.zip"
   appcast 'https://github.com/source-foundry/Hack/releases.atom',
-          checkpoint: '9283b6f55b192df976de026543ee62cd4576d8e60a186e02cc89a8b55f4cc90f'
+          checkpoint: 'f023893751e9b66172e9f4498568609ac4a3dae173f8a8944c83263af714cc22'
   name 'Hack'
   homepage 'http://sourcefoundry.org/hack/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.