### PR TITLE
fix typo in fira-mono-for-powerline font

### DIFF
--- a/Casks/font-fira-mono-for-powerline.rb
+++ b/Casks/font-fira-mono-for-powerline.rb
@@ -5,10 +5,10 @@ cask 'font-fira-mono-for-powerline' do
   url 'https://github.com/powerline/fonts/trunk/FiraMono',
       using:      :svn,
       trust_cert: true
-  name 'Fira Mono for Poweline'
+  name 'Fira Mono for Powerline'
   homepage 'https://github.com/powerline/fonts/tree/master/FiraMono'
 
-  font 'FuraMono-Bold Powerline.otf'
-  font 'FuraMono-Medium Powerline.otf'
-  font 'FuraMono-Regular Powerline.otf'
+  font 'FiraMono-Bold Powerline.otf'
+  font 'FiraMono-Medium Powerline.otf'
+  font 'FiraMono-Regular Powerline.otf'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

- [  ] `brew cask audit --download {{cask_file}}` is error-free.
- [  ] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ x ] The commit message includes the cask’s name and version.
(Didn't see a version)

Just some typo fixes. I noticed that it installed on my computer as "FuraMono" and that just ain't right!