### PR TITLE
Update font-rounded-m-plus: depends on unar

### DIFF
--- a/Casks/font-rounded-m-plus.rb
+++ b/Casks/font-rounded-m-plus.rb
@@ -7,6 +7,8 @@ cask 'font-rounded-m-plus' do
   name 'Rounded M+'
   homepage 'http://jikasei.me/font/rounded-mplus/'
 
+  depends_on formula: 'unar'
+
   font 'rounded-mplus-1c-black.ttf'
   font 'rounded-mplus-1c-bold.ttf'
   font 'rounded-mplus-1c-heavy.ttf'


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.

Closes https://github.com/caskroom/homebrew-fonts/issues/1528