### PR TITLE
Update font-cica to 2.1.0

### DIFF
--- a/Casks/font-cica.rb
+++ b/Casks/font-cica.rb
@@ -1,10 +1,10 @@
 cask 'font-cica' do
-  version '2.0.5'
-  sha256 '226d4ef7cdaad2f34c072e899a17ff85f5d01b068735d2d3ea3f8b34a9499ddd'
+  version '2.1.0'
+  sha256 '6b1e4750a3c07995bbcfaadcec0be5ed73de26ca1dc2082dc712b296af35b59b'
 
   url "https://github.com/miiton/Cica/releases/download/v#{version}/Cica_v#{version}.zip"
   appcast 'https://github.com/miiton/Cica/releases.atom',
-          checkpoint: '271dd303e57f9417d4ff235d6d6f69f566134bc9cbcba0dc3a94d2d61f9efee1'
+          checkpoint: '5e4a5f7d7641654c566f85e9b37dc2a60176995b3add7c42345694eb476b3a87'
   name 'Cica'
   homepage 'https://github.com/miiton/Cica'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.