### PR TITLE
Update font-vazir to 18.0.0

### DIFF
--- a/Casks/font-vazir.rb
+++ b/Casks/font-vazir.rb
@@ -1,11 +1,11 @@
 cask 'font-vazir' do
-  version '16.1.0'
-  sha256 'acd48aafe25b0b3f740b9136d7f4f73a184743d61c593016a3e34c92fabdc0a5'
+  version '18.0.0'
+  sha256 'ca7251c5448c0c356d4f409e71636dd678be0edd3aa1db354fd8540653617ae9'
 
   # github.com/rastikerdar was verified as official when first introduced to the cask
   url "https://github.com/rastikerdar/vazir-font/releases/download/v#{version}/vazir-font-v#{version}.zip"
   appcast 'https://github.com/rastikerdar/vazir-font/releases.atom',
-          checkpoint: 'bcc7b58994b2c1fc4b2c560fac949e24c3771d32fe48a7f21a516a966946776b'
+          checkpoint: '468fe52d8f4437e2f660ad27f20bd8b4820edaec04b665f97e2138350f1abb61'
   name 'Vazir'
   homepage 'https://rastikerdar.github.io/vazir-font/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.