### PR TITLE
Update font-inconsolatalgc-nerd-font-mono to 2.0.0

### DIFF
--- a/Casks/font-inconsolatalgc-nerd-font-mono.rb
+++ b/Casks/font-inconsolatalgc-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-inconsolatalgc-nerd-font-mono' do
-  version '1.2.0'
-  sha256 '0fd2492b0c5c4140718120ae97517efb0236694b1a3e10252492addfc38fffda'
+  version '2.0.0'
+  sha256 'dadb77ba0f1a139933456b7ccbc353960e87a714e928203fdff300832d9fae5d'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/InconsolataLGC.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name 'InconsolataLGC Nerd Font Mono (InconsolataLGC)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.