### PR TITLE
Update font-3270-nerd-font-mono to 2.0.0

### DIFF
--- a/Casks/font-3270-nerd-font-mono.rb
+++ b/Casks/font-3270-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-3270-nerd-font-mono' do
-  version '1.2.0'
-  sha256 '37cd9e4c31b7f585a202ce85f358e318e6042de489e668c948ecee0d0daf4472'
+  version '2.0.0'
+  sha256 '4fb411ff4a6aaaeb6482047825416b21131d9f301c56222f22f86a1ffb502f81'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/3270.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name '3270Medium Nerd Font (3270)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.