### PR TITLE
Update font-bitstreamverasansmono-nerd-font to 2.0.0

### DIFF
--- a/Casks/font-bitstreamverasansmono-nerd-font.rb
+++ b/Casks/font-bitstreamverasansmono-nerd-font.rb
@@ -1,10 +1,10 @@
 cask 'font-bitstreamverasansmono-nerd-font' do
-  version '1.2.0'
-  sha256 'caa575cf0df9ab974f531c681b9ec9c7fb9a1b313e336bb820d5a6627857e95d'
+  version '2.0.0'
+  sha256 '7a5537c1b6e51fdebba73cc4925ebe937d215068f43e916caa049e90c28ef7ad'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/BitstreamVeraSansMono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name 'BitstreamVeraSansMono Nerd Font (BitstreamVeraSansMono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.