### PR TITLE
Update font-codenewroman-nerd-font-mono to 2.0.0

### DIFF
--- a/Casks/font-codenewroman-nerd-font-mono.rb
+++ b/Casks/font-codenewroman-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-codenewroman-nerd-font-mono' do
-  version '1.2.0'
-  sha256 'b4302eafd46bb7ffa4a5e349d298e2cfd68a82c02c68e9d2235f4d4d383668a3'
+  version '2.0.0'
+  sha256 '46329c3264bc13a3815c7de4dbc7112ee007f14572216efcd98cb9a84fee082e'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/CodeNewRoman.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name 'CodeNewRoman Nerd Font (CodeNewRoman)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.