### PR TITLE
Update font-cousine-nerd-font-mono to 2.0.0

### DIFF
--- a/Casks/font-cousine-nerd-font-mono.rb
+++ b/Casks/font-cousine-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-cousine-nerd-font-mono' do
-  version '1.2.0'
-  sha256 'ee8576c433de415fc52ee59985e46eb510c3dd8e6ab516c409804d0e05ae77e7'
+  version '2.0.0'
+  sha256 'bb0fb3ba1d826e075f6779f1235617e2d40469425a4dc4acb18a14050cccc4c2'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Cousine.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name 'Cousine Nerd Font Mono (Cousine)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.