### PR TITLE
Update font-droidsansmono-nerd-font-mono to 2.0.0

### DIFF
--- a/Casks/font-droidsansmono-nerd-font-mono.rb
+++ b/Casks/font-droidsansmono-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-droidsansmono-nerd-font-mono' do
-  version '1.2.0'
-  sha256 'c01bd116d1d828d6e55fdc2cfd55e3e0874f53c8a3ca1c1e4d359acd0dd9171b'
+  version '2.0.0'
+  sha256 '7b9bb25683bd7eb00316a0abdc09510988d7b326b7d9745de7dde7edb03d4087'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/DroidSansMono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name 'DroidSansMonoForPowerline Nerd Font (DroidSansMono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.