### PR TITLE
Update font-firamono-nerd-font-mono to 2.0.0

### DIFF
--- a/Casks/font-firamono-nerd-font-mono.rb
+++ b/Casks/font-firamono-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-firamono-nerd-font-mono' do
-  version '1.2.0'
-  sha256 '77ffee4498e23e3215edc9ea6eefa9f10b03deb6815dc3ccb9ad3336cd478f5c'
+  version '2.0.0'
+  sha256 '6d6940471855cc2cbc7048f18d56d4f4f9e77e496d1c2c5cec673bdc04365642'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/FiraMono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name 'FuraMonoForPowerline Nerd Font (FiraMono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.