### PR TITLE
Update font-go-mono-nerd-font-mono to 2.0.0

### DIFF
--- a/Casks/font-go-mono-nerd-font-mono.rb
+++ b/Casks/font-go-mono-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-go-mono-nerd-font-mono' do
-  version '1.2.0'
-  sha256 'c6873e9563766a6ff9b36b35d25366bad406a0423b181a33cda6a8e58dd4bfc9'
+  version '2.0.0'
+  sha256 '6b4742103210e403813cdfa5c8846f22431c8bcf5c82fe9af3a9d9bfb6900470'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Go-Mono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name 'GoMono Nerd Font Mono (Go-Mono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.