### PR TITLE
Update font-heavydata-nerd-font-mono to 2.0.0

### DIFF
--- a/Casks/font-heavydata-nerd-font-mono.rb
+++ b/Casks/font-heavydata-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-heavydata-nerd-font-mono' do
-  version '1.2.0'
-  sha256 '101310c911cc41e159e100a9afc2df3bc5d2e212475c9a53eec785904d9135cf'
+  version '2.0.0'
+  sha256 '1b7218999ed0b20882e9498618f88c56c548e22feeb89d098f70784d36e15c47'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/HeavyData.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name 'HeavyData Nerd Font (HeavyData)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.