### PR TITLE
Update font-hermit-nerd-font-mono to 2.0.0

### DIFF
--- a/Casks/font-hermit-nerd-font-mono.rb
+++ b/Casks/font-hermit-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-hermit-nerd-font-mono' do
-  version '1.2.0'
-  sha256 '98da4c26a22cf7d8c3161e71d7ae5ebfa592b8312dc39426db646a1f32623b25'
+  version '2.0.0'
+  sha256 '5414b1fb0ea62463749c5b9107b338c89e45267b362124af21dbdc53be84b7ba'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Hermit.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name 'Hurmit Nerd Font (Hermit)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.