### PR TITLE
Update font-inconsolata-nerd-font-mono to 2.0.0

### DIFF
--- a/Casks/font-inconsolata-nerd-font-mono.rb
+++ b/Casks/font-inconsolata-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-inconsolata-nerd-font-mono' do
-  version '1.2.0'
-  sha256 '6a94fdd4a81b1877c975acc6657a07ab844ec9de351416483dacaab2c01d7e2e'
+  version '2.0.0'
+  sha256 '72b68702546414e3da8dba423b6ea14fcf7b913e2723f35d11e44f7877296d9a'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Inconsolata.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name 'InconsolataForPowerline Nerd Font (Inconsolata)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.