### PR TITLE
Update font-liberationmono-nerd-font-mono to 2.0.0

### DIFF
--- a/Casks/font-liberationmono-nerd-font-mono.rb
+++ b/Casks/font-liberationmono-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-liberationmono-nerd-font-mono' do
-  version '1.2.0'
-  sha256 '8eb8f93c4a4ea15044790ddc1dfd50c5acaf883a2f2e6cb148a5e0a2e0224547'
+  version '2.0.0'
+  sha256 '09a6f5e571993318d123932d05c2da9dd0b612f294bc3575e50c644fba014b9e'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/LiberationMono.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name 'LiterationMonoPowerline Nerd Font (LiberationMono)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.