### PR TITLE
Update font-monoid-nerd-font-mono to 2.0.0

### DIFF
--- a/Casks/font-monoid-nerd-font-mono.rb
+++ b/Casks/font-monoid-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-monoid-nerd-font-mono' do
-  version '1.2.0'
-  sha256 '57d16688a7b77f920472fb44e35dfae4cd4c8a3b718e1c622a84519f39231c5c'
+  version '2.0.0'
+  sha256 '3e3dc6be4484815ab85728032f2cdbcf8703aec425f0d5abbe96fb272448e13a'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Monoid.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name 'Monoid Nerd Font (Monoid)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.