### PR TITLE
Update font-terminus-nerd-font-mono to 2.0.0

### DIFF
--- a/Casks/font-terminus-nerd-font-mono.rb
+++ b/Casks/font-terminus-nerd-font-mono.rb
@@ -1,10 +1,10 @@
 cask 'font-terminus-nerd-font-mono' do
-  version '1.2.0'
-  sha256 '3beef1d5ae482a3273cd5331cc643a57202bfab4c4fde793a024c0233a42901d'
+  version '2.0.0'
+  sha256 '82e546101f2a70faf39c1f32aa240c6d85841da8329d01efdf9afd67acecfdb1'
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/Terminus.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: '7dedec17cde17542418131f94e739265707a4abe9d0773287d14f175c02325f7'
+          checkpoint: '722a75922628bdd6138fdd43bbf5f21d2ceeb711768fa1839942636dc1dd6e83'
   name 'TerminessTTF Nerd Font (Terminus)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.