### PR TITLE
Update font-3270 to 1.2.23,d250fd9

### DIFF
--- a/Casks/font-3270.rb
+++ b/Casks/font-3270.rb
@@ -1,8 +1,10 @@
 cask 'font-3270' do
-  version '1.2.18,408b9bd'
-  sha256 'cab1323b1da858460c3dc77c03b0446147635d5fce93d575f4d098265e3cf664'
+  version '1.2.23,d250fd9'
+  sha256 '9cf7235088b3afe7827b24fec534a569b5cab15c26e0b5b6956cc2af0db837b6'
 
   url "https://github.com/rbanffy/3270font/releases/download/v#{version.before_comma}/3270_fonts_#{version.after_comma}.zip"
+  appcast 'https://github.com/rbanffy/3270font/releases.atom',
+          checkpoint: '9691d24b9ed2513cc40a29872f9f4ef6a295bf964aff4dabcce5b53416522fa7'
   name 'IBM 3270'
   homepage 'https://github.com/rbanffy/3270font'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.