### PR TITLE
Add italics variant for SourceCodePro Nerd Font

### DIFF
--- a/Casks/font-sourcecodepro-nerd-font-mono.rb
+++ b/Casks/font-sourcecodepro-nerd-font-mono.rb
@@ -4,15 +4,21 @@ cask 'font-sourcecodepro-nerd-font-mono' do
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/SourceCodePro.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'fc41f3d5a5b0df76caa2586a08c53a4571f05adb0fe0a6e30897f43899ee6ea2'
+          checkpoint: '9f5824afb5ed43113f1b58a45f050d6fe27c7c3435343775b7a3c3313c154397'
   name 'SauceCodePro Nerd Font (SourceCodePro)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 
   font 'Sauce Code Pro Bold Nerd Font Complete Mono.ttf'
+  font 'Sauce Code Pro Bold Italic Nerd Font Complete Mono.ttf'
   font 'Sauce Code Pro Medium Nerd Font Complete Mono.ttf'
+  font 'Sauce Code Pro Medium Italic Nerd Font Complete Mono.ttf'
   font 'Sauce Code Pro ExtraLight Nerd Font Complete Mono.ttf'
+  font 'Sauce Code Pro ExtraLight Italic Nerd Font Complete Mono.ttf'
   font 'Sauce Code Pro Black Nerd Font Complete Mono.ttf'
+  font 'Sauce Code Pro Black Italic Nerd Font Complete Mono.ttf'
   font 'Sauce Code Pro Nerd Font Complete Mono.ttf'
   font 'Sauce Code Pro Semibold Nerd Font Complete Mono.ttf'
+  font 'Sauce Code Pro Semibold Italic Nerd Font Complete Mono.ttf'
   font 'Sauce Code Pro Light Nerd Font Complete Mono.ttf'
+  font 'Sauce Code Pro Light Italic Nerd Font Complete Mono.ttf'
 end

--- a/Casks/font-sourcecodepro-nerd-font.rb
+++ b/Casks/font-sourcecodepro-nerd-font.rb
@@ -4,15 +4,21 @@ cask 'font-sourcecodepro-nerd-font' do
 
   url "https://github.com/ryanoasis/nerd-fonts/releases/download/v#{version}/SourceCodePro.zip"
   appcast 'https://github.com/ryanoasis/nerd-fonts/releases.atom',
-          checkpoint: 'fc41f3d5a5b0df76caa2586a08c53a4571f05adb0fe0a6e30897f43899ee6ea2'
+          checkpoint: '9f5824afb5ed43113f1b58a45f050d6fe27c7c3435343775b7a3c3313c154397'
   name 'SauceCodePro Nerd Font (SourceCodePro)'
   homepage 'https://github.com/ryanoasis/nerd-fonts'
 
   font 'Sauce Code Pro Bold Nerd Font Complete.ttf'
+  font 'Sauce Code Pro Bold Italic Nerd Font Complete.ttf'
   font 'Sauce Code Pro Medium Nerd Font Complete.ttf'
+  font 'Sauce Code Pro Medium Italic Nerd Font Complete.ttf'
   font 'Sauce Code Pro ExtraLight Nerd Font Complete.ttf'
+  font 'Sauce Code Pro ExtraLight Italic Nerd Font Complete.ttf'
   font 'Sauce Code Pro Black Nerd Font Complete.ttf'
+  font 'Sauce Code Pro Black Italic Nerd Font Complete.ttf'
   font 'Sauce Code Pro Nerd Font Complete.ttf'
   font 'Sauce Code Pro Semibold Nerd Font Complete.ttf'
+  font 'Sauce Code Pro Semibold Italic Nerd Font Complete.ttf'
   font 'Sauce Code Pro Light Nerd Font Complete.ttf'
+  font 'Sauce Code Pro Light Italic Nerd Font Complete.ttf'
 end


### PR DESCRIPTION
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [ ] The commit message includes the cask’s name and version: —> Did not change Version Number.

- - -

Version 2.0.0 of the Nerd Fonts included italics variants for the SourceCodePro Typeface. This adds those additional Fonts.

I did change the `checkpoint` checksum using `brew cask _appcast_checkpoint --calculate "{{appcast_url}}"`, because I had an error otherwise—I hope that was correct.