### PR TITLE
Add Simple Line Icons font

### DIFF
--- a/Casks/font-simple-line-icons.rb
+++ b/Casks/font-simple-line-icons.rb
@@ -2,11 +2,12 @@ cask 'font-simple-line-icons' do
   version '2.4.1'
   sha256 'fd0e9edd1550f8f8ded705160f0e433aae4170fe9f21a595eb583ac54c7e2d12'
 
-  url 'https://github.com/thesabbir/simple-line-icons/archive/#{version}.zip'
+  # github.com/thesabbir/simple-line-icons was verified as official when first introduced to the cask
+  url "https://github.com/thesabbir/simple-line-icons/archive/#{version}.zip"
   appcast 'https://github.com/thesabbir/simple-line-icons/releases.atom',
-            checkpoint: '7e51c187ad2d125bf82c310b02bc47d775b802dc6485dfe0d089368653d71314'
+          checkpoint: 'a54dd5378eaa2bbe2ab51aec5101ca50d160df9f7a010bbefc085868eeb56447'
   name 'Simple Line Icons'
-  homepage 'http://simplelineicons.com'
+  homepage 'http://simplelineicons.com/'
 
-  font 'simple-line-icons-#{version}/fonts/Simple-Line-Icons.ttf'
+  font "simple-line-icons-#{version}/fonts/Simple-Line-Icons.ttf"
 end

--- a/Casks/font-simple-line-icons.rb
+++ b/Casks/font-simple-line-icons.rb
@@ -1,0 +1,12 @@
+cask 'font-simple-line-icons' do
+  version '2.4.1'
+  sha256 'fd0e9edd1550f8f8ded705160f0e433aae4170fe9f21a595eb583ac54c7e2d12'
+
+  url 'https://github.com/thesabbir/simple-line-icons/archive/#{version}.zip'
+  appcast 'https://github.com/thesabbir/simple-line-icons/releases.atom',
+            checkpoint: '7e51c187ad2d125bf82c310b02bc47d775b802dc6485dfe0d089368653d71314'
+  name 'Simple Line Icons'
+  homepage 'http://simplelineicons.com'
+
+  font 'simple-line-icons-#{version}/fonts/Simple-Line-Icons.ttf'
+end


### PR DESCRIPTION
Add Simple Line Icons font version 2.4.1.
Its homepage can be found [here](http://simplelineicons.com/) and the GitHub project [here](https://github.com/thesabbir/simple-line-icons)

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256