### PR TITLE
Update font-source-han-noto-cjk to 20180418

### DIFF
--- a/Casks/font-source-han-noto-cjk.rb
+++ b/Casks/font-source-han-noto-cjk.rb
@@ -1,10 +1,10 @@
 cask 'font-source-han-noto-cjk' do
-  version '20180125'
-  sha256 'dcc01a6f98105025612eec9fc8c5c63cdd9cfd30f4967269fddee744725208a7'
+  version '20180418'
+  sha256 '55b2eebafb76193208c979b43ef22b78d50b96ce7a795c31f18dd3cf3137e3cb'
 
   url "https://github.com/adobe-fonts/source-han-super-otc/releases/download/#{version}/SourceHanNotoCJK.ttc"
   appcast 'https://github.com/adobe-fonts/source-han-super-otc/releases.atom',
-          checkpoint: 'd88b53e5e0e853369076f84a0c415b1cd69f724ebe9274d356ad76a14085c3af'
+          checkpoint: '142014cae5bcca38e454e1049d9f7ab14c26c96c05d26bba6b31c8fca019b40b'
   name 'Source Han Noto CJK'
   homepage 'https://github.com/adobe-fonts/source-han-super-otc'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.