### PR TITLE
Update font-vazir to 18.0.1

### DIFF
--- a/Casks/font-vazir.rb
+++ b/Casks/font-vazir.rb
@@ -1,11 +1,11 @@
 cask 'font-vazir' do
-  version '18.0.0'
-  sha256 'ca7251c5448c0c356d4f409e71636dd678be0edd3aa1db354fd8540653617ae9'
+  version '18.0.1'
+  sha256 '992b00148dfb30f27f03f885175a71dd69f1846713b047e6f72a345d3e6eea2a'
 
   # github.com/rastikerdar was verified as official when first introduced to the cask
   url "https://github.com/rastikerdar/vazir-font/releases/download/v#{version}/vazir-font-v#{version}.zip"
   appcast 'https://github.com/rastikerdar/vazir-font/releases.atom',
-          checkpoint: '468fe52d8f4437e2f660ad27f20bd8b4820edaec04b665f97e2138350f1abb61'
+          checkpoint: '85f71ed1248f615e10483aaaa82e984590e2399b61a3ee273dcfe653c36c6022'
   name 'Vazir'
   homepage 'https://rastikerdar.github.io/vazir-font/'
 


### PR DESCRIPTION
After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.