### PR TITLE
Add Aegean v.10.00

### DIFF
--- a/Casks/font-aegean.rb
+++ b/Casks/font-aegean.rb
@@ -1,0 +1,12 @@
+cask 'font-aegean' do
+  version :latest
+  sha256 :no_check
+
+  url 'http://users.teilar.gr/~g1951d/Aegean.zip'
+  name 'Aegean'
+  homepage 'http://users.teilar.gr/~g1951d/'
+
+  font 'Hinted/Aegean_Hinted.ttf'
+  font 'Hinted/CMinoan_Hinted.ttf'
+  font 'Hinted/CretanH_Hinted.ttf'
+end


### PR DESCRIPTION
George Douros fonts are widely used, and Aegean is the only font I know that supports the Linear A block.

---
<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.

Additionally, if **adding a new cask**:

- [x] Named the cask according to the [token reference].
- [x] `brew cask install {{cask_file}}` worked successfully.
- [x] `brew cask uninstall {{cask_file}}` worked successfully.
- [x] Checked there are no [open pull requests] for the same cask.
- [x] Checked the cask was not already refused in [closed issues].
- [x] Checked the cask is submitted to [the correct repo].

[token reference]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/token_reference.md
[open pull requests]: https://github.com/caskroom/homebrew-fonts/pulls
[closed issues]: https://github.com/caskroom/homebrew-fonts/issues?q=is%3Aissue+is%3Aclosed
[the correct repo]: https://github.com/caskroom/homebrew-cask/blob/master/doc/development/adding_a_cask.md#finding-a-home-for-your-cask
[version-checksum]: https://github.com/caskroom/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256
